### PR TITLE
Clear buttons on Crew page and voyage calculator

### DIFF
--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Table, Input, Pagination, Dropdown, Popup, Icon } from 'semantic-ui-react';
+import { Table, Input, Pagination, Dropdown, Popup, Icon, Button } from 'semantic-ui-react';
 
 import * as SearchString from 'search-string';
 import * as localForage from 'localforage';
@@ -98,6 +98,11 @@ export class SearchableTable extends PureComponent<SearchableTableProps, Searcha
 		this.setState({ searchFilter: value, pagination_page: 1 });
 	}
 
+	_onClearFilter() {
+		localForage.setItem<string>('searchFilter', '');
+		this.setState({ searchFilter: '', pagination_page: 1 });
+	}
+
 	renderTableHeader(column: any, direction: 'descending' | 'ascending' | null): JSX.Element {
 		return (
 			<Table.Row>
@@ -132,11 +137,16 @@ export class SearchableTable extends PureComponent<SearchableTableProps, Searcha
 			<div>
 				<Input
 					style={{ width: '50%' }}
-					icon="search"
+					iconPosition="left"
 					placeholder="Search..."
 					value={this.state.searchFilter}
-					onChange={(e, { value }) => this._onChangeFilter(value)}
-				/>
+					onChange={(e, { value }) => this._onChangeFilter(value)}>
+						<input />
+						<Icon name='search' />
+						<Button icon onClick={() => this._onClearFilter()} >
+							<Icon name='delete' />
+						</Button>
+				</Input>
 
 				<Popup wide trigger={<Icon name="help" />} header={'Advanced search'} content={this.props.explanation} />
 

--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -98,11 +98,6 @@ export class SearchableTable extends PureComponent<SearchableTableProps, Searcha
 		this.setState({ searchFilter: value, pagination_page: 1 });
 	}
 
-	_onClearFilter() {
-		localForage.setItem<string>('searchFilter', '');
-		this.setState({ searchFilter: '', pagination_page: 1 });
-	}
-
 	renderTableHeader(column: any, direction: 'descending' | 'ascending' | null): JSX.Element {
 		return (
 			<Table.Row>
@@ -143,7 +138,7 @@ export class SearchableTable extends PureComponent<SearchableTableProps, Searcha
 					onChange={(e, { value }) => this._onChangeFilter(value)}>
 						<input />
 						<Icon name='search' />
-						<Button icon onClick={() => this._onClearFilter()} >
+						<Button icon onClick={() => this._onChangeFilter('')} >
 							<Icon name='delete' />
 						</Button>
 				</Input>

--- a/static/styles/semantic.slate.css
+++ b/static/styles/semantic.slate.css
@@ -33769,6 +33769,68 @@ select.ui.dropdown {
 }
 
 /*******************************
+         Theme Overrides
+*******************************/
+
+/* Dropdown Carets */
+
+@font-face {
+  font-family: 'Dropdown';
+  src: url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAVgAA8AAAAACFAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABWAAAABwAAAAchGgaq0dERUYAAAF0AAAAHAAAAB4AJwAPT1MvMgAAAZAAAABDAAAAVnW4TJdjbWFwAAAB1AAAAEsAAAFS8CcaqmN2dCAAAAIgAAAABAAAAAQAEQFEZ2FzcAAAAiQAAAAIAAAACP//AANnbHlmAAACLAAAAQoAAAGkrRHP9WhlYWQAAAM4AAAAMAAAADYPK8YyaGhlYQAAA2gAAAAdAAAAJANCAb1obXR4AAADiAAAACIAAAAiCBkAOGxvY2EAAAOsAAAAFAAAABQBnAIybWF4cAAAA8AAAAAfAAAAIAEVAF5uYW1lAAAD4AAAATAAAAKMFGlj5HBvc3QAAAUQAAAARgAAAHJoedjqd2ViZgAABVgAAAAGAAAABrO7W5UAAAABAAAAANXulPUAAAAA1r4hgAAAAADXu2Q1eNpjYGRgYOABYjEgZmJgBEIOIGYB8xgAA/YAN3jaY2BktGOcwMDKwMI4jTGNgYHBHUp/ZZBkaGFgYGJgZWbACgLSXFMYHFT/fLjFeOD/AQY9xjMMbkBhRpAcAN48DQYAeNpjYGBgZoBgGQZGBhDwAfIYwXwWBgMgzQGETAwMqn8+8H649f8/lHX9//9b7Pzf+fWgusCAkY0BzmUE6gHpQwGMDMMeAACbxg7SAAARAUQAAAAB//8AAnjadZBPSsNAGMXfS+yMqYgOhpSuSlKadmUhiVEhEMQzFF22m17BbbvzCh5BXCUn6EG8gjeQ4DepwYo4i+/ffL95j4EDA+CFC7jQuKyIeVHrI3wkleq9F7XrSInKteOeHdda8bOoaeepSc00NWPz/LRec9G8GabyGtEdF7h19z033GAMTK7zbM42xNEZpzYof0RtQ5CUHAQJ73OtVyutc+3b7Ou//b8XNlsPx3jgjUifABdhEohKJJL5iM5p39uqc7X1+sRQSqmGrUVhlsJ4lpmEUVwyT8SUYtg0P9DyNzPADDs+tjrGV6KRCRfsui3eHcL4/p8ZXvfMlcnEU+CLv7hDykOP+AKTPTxbAAB42mNgZGBgAGKuf5KP4vltvjLIMzGAwLV9ig0g+vruFFMQzdjACOJzMIClARh0CTJ42mNgZGBgPPD/AJD8wgAEjA0MjAyogAMAbOQEAQAAAAC7ABEAAAAAAKoAAAH0AAABgAAAAUAACAFAAAgAwAAXAAAAAAAAACoAKgAqADIAbACGAKAAugDSeNpjYGRgYOBkUGFgYgABEMkFhAwM/xn0QAIADdUBdAB42qWQvUoDQRSFv3GjaISUQaymSmGxJoGAsRC0iPYLsU50Y6IxrvlRtPCJJKUPIBb+PIHv4EN4djKuKAqCDHfmu+feOdwZoMCUAJNbAlYUMzaUlM14jjxbngOq7HnOia89z1Pk1vMCa9x7ztPkzfMyJbPj+ZGi6Xp+omxuPD+zaD7meaFg7mb8GrBqHmhwxoAxlm0uiRkpP9X5m26pKRoMxTGR1D49Dv/Yb/91o6l8qL6eu5n2hZQzn68utR9m3FU2cB4t9cdSLG2utI+44Eh/P9bqKO+oJ/WxmXssj77YkrjasZQD6SFddythk3Wtzrf+UF2p076Udla1VNzsERP3kkjVRKel7mp1udXYcHtZSlV7RfmJe1GiFWveluaeKD5/MuJcSk8Tpm/vvwPIbmJleNpjYGKAAFYG7ICTgYGRiZGZkYWRlZGNkZ2Rg5GTLT2nsiDDEEIZsZfmZRqZujmDaDcDAxcI7WIOpS2gtCWUdgQAZkcSmQAAAAFblbO6AAA=) format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+.ui.dropdown > .dropdown.icon {
+  font-family: 'Dropdown';
+  line-height: 1;
+  height: 1em;
+  width: 1.23em;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  font-weight: normal;
+  font-style: normal;
+  text-align: center;
+}
+
+.ui.dropdown > .dropdown.icon {
+  width: auto;
+}
+
+.ui.dropdown > .dropdown.icon:before {
+  content: '\f0d7';
+}
+
+/* Sub Menu */
+
+.ui.dropdown .menu .item .dropdown.icon:before {
+  content: '\f0da' ;
+}
+
+.ui.dropdown .item .left.dropdown.icon:before,
+.ui.dropdown .left.menu .item .dropdown.icon:before {
+  content: "\f0d9" ;
+}
+
+/* Vertical Menu Dropdown */
+
+.ui.vertical.menu .dropdown.item > .dropdown.icon:before {
+  content: "\f0da" ;
+}
+
+.ui.dropdown > .clear.icon:before {
+  content: "\f00d";
+}
+
+/* Icons for Reference (Subsetted in 2.4.0)
+  .dropdown.down:before { content: "\f0d7"; }
+  .dropdown.up:before { content: "\f0d8"; }
+  .dropdown.left:before { content: "\f0d9"; }
+  .dropdown.right:before { content: "\f0da"; }
+  .dropdown.close:before { content: "\f00d"; }
+*/
+
+/*******************************
         User Overrides
 *******************************/
 /*!


### PR DESCRIPTION
Closes #20 by adding clear button to the crew search page.  Also fixes a 'slate' theme issue that left the downward caret icon showing when the voyage crew selector should have shown the clear icon (wasn't broken on light theme)