### PR TITLE
Fix image URLs on item_info page to use correct env var

### DIFF
--- a/src/pages/item_info.tsx
+++ b/src/pages/item_info.tsx
@@ -138,7 +138,7 @@ class ItemInfoPage extends Component<ItemInfoPageProps, ItemInfoPageState> {
 						{item_data.item.name}{' '}
 						<Rating rating={item_data.item.rarity} maxRating={item_data.item.rarity} size="large" disabled />
 					</Header>
-					<Image size="small" src={`${process.env._GATSBY_ASSETS_URL}${item_data.item.imageUrl}`} />
+					<Image size="small" src={`${process.env.GATSBY_ASSETS_URL}${item_data.item.imageUrl}`} />
 
 					<br />
 
@@ -161,7 +161,7 @@ class ItemInfoPage extends Component<ItemInfoPageProps, ItemInfoPageState> {
 													style={{ display: 'flex', cursor: 'zoom-in' }}
 													icon={
 														<ItemDisplay
-															src={`${process.env._GATSBY_ASSETS_URL}${entry.equipment.imageUrl}`}
+															src={`${process.env.GATSBY_ASSETS_URL}${entry.equipment.imageUrl}`}
 															size={48}
 															maxRarity={entry.equipment.rarity}
 															rarity={entry.equipment.rarity}
@@ -204,7 +204,7 @@ class ItemInfoPage extends Component<ItemInfoPageProps, ItemInfoPageState> {
 											style={{ display: 'flex' }}
 											icon={
 												<ItemDisplay
-													src={`${process.env._GATSBY_ASSETS_URL}${entry.crew.imageUrlPortrait}`}
+													src={`${process.env.GATSBY_ASSETS_URL}${entry.crew.imageUrlPortrait}`}
 													size={60}
 													maxRarity={entry.crew.max_rarity}
 													rarity={entry.crew.max_rarity}
@@ -229,7 +229,7 @@ class ItemInfoPage extends Component<ItemInfoPageProps, ItemInfoPageState> {
 											style={{ display: 'flex', cursor: 'zoom-in' }}
 											icon={
 												<ItemDisplay
-													src={`${process.env._GATSBY_ASSETS_URL}${entry.imageUrl}`}
+													src={`${process.env.GATSBY_ASSETS_URL}${entry.imageUrl}`}
 													size={48}
 													maxRarity={entry.rarity}
 													rarity={entry.rarity}


### PR DESCRIPTION
I noticed images were broken on `item_info` - looks like a stray underscore is to blame. 

Yay for simple fixes 😃