### PR TITLE
Find variants by trait

### DIFF
--- a/src/components/crewvariants.tsx
+++ b/src/components/crewvariants.tsx
@@ -4,11 +4,11 @@ import ItemDisplay from '../components/itemdisplay';
 import { Link } from 'gatsby';
 
 type CrewVariantsProps = {
-	short_name: string;
+	traits_hidden: any[]
 };
 
 type CrewVariantsState = {
-	variants: any[];
+	variants: any[]
 };
 
 class CrewVariants extends Component<CrewVariantsProps, CrewVariantsState> {
@@ -17,33 +17,68 @@ class CrewVariants extends Component<CrewVariantsProps, CrewVariantsState> {
 	};
 
 	componentDidMount() {
+		// Get variant names from traits_hidden
+		let ignore = [
+			'tos','tas','tng','ds9','voy','ent','dsc','pic',
+			'female','male',
+			'artificial_life','nonhuman','organic','species_8472',
+			'admiral','captain','commander','lieutenant_commander','lieutenant','ensign','general','nagus','first_officer',
+			'ageofsail','bridge_crew','evsuit','gauntlet_jackpot','mirror','niners','original',
+			'crew_max_rarity_5','crew_max_rarity_4','crew_max_rarity_3','crew_max_rarity_2','crew_max_rarity_1',
+			'spock_tos' /* 'spock_tos' Spocks also have 'spock' trait so use that and ignore _tos for now */
+		];
+		let variantTraits = [];
+		for (let i = 0; i < this.props.traits_hidden.length; i++) {
+			let trait = this.props.traits_hidden[i];
+			if (ignore.indexOf(trait) == -1) variantTraits.push(trait);
+		}
+
+		let self = this;
 		fetch('/structured/crew.json')
 			.then(response => response.json())
-			.then(crew => this.setState({ variants: crew.filter(c => c.short_name === this.props.short_name) }));
+			.then(crew => {
+				let variants = [];
+				variantTraits.forEach(function(trait) {
+					let found = crew.filter(c => c.traits_hidden.indexOf(trait) >= 0);
+					// Ignore variant group if crew is the only member of the group
+					if (found.length > 1) {
+						found.sort(function(a, b) {
+							if (a.max_rarity == b.max_rarity)
+								return a.name.localeCompare(b.name);
+							return a.max_rarity - b.max_rarity;
+						});
+						// short_name may not always be the best name to use, depending on the first variant
+						variants.push({'name': found[0].short_name, 'trait_variants': found});
+					}
+				});
+				self.setState({ 'variants': variants });
+			});
 	}
 
 	render() {
-		if (!this.props.short_name || this.state.variants.length < 2) {
+		if (this.state.variants.length == 0) {
 			return <span />;
 		}
 
 		return (
-			<Segment>
-				<Header as='h4'>Other variants of {this.props.short_name}</Header>
-				<Grid columns={4} centered padded>
-					{this.state.variants.map(variant => (
-						<Grid.Column key={variant.symbol} textAlign='center'>
-							<ItemDisplay
-								src={`${process.env.GATSBY_ASSETS_URL}${variant.imageUrlPortrait}`}
-								size={128}
-								maxRarity={variant.max_rarity}
-								rarity={variant.max_rarity}
-							/>
-							<Link to={`/crew/${variant.symbol}/`}>{variant.name}</Link>
-						</Grid.Column>
-					))}
-				</Grid>
-			</Segment>
+			this.state.variants.map(group => (
+				<Segment>
+					<Header as='h4'>Variants of {group.name}</Header>
+					<Grid centered padded>
+						{group.trait_variants.map(variant => (
+							<Grid.Column key={variant.symbol} textAlign='center' mobile={8} tablet={5} computer={4}>
+								<ItemDisplay
+									src={`${process.env.GATSBY_ASSETS_URL}${variant.imageUrlPortrait}`}
+									size={128}
+									maxRarity={variant.max_rarity}
+									rarity={variant.max_rarity}
+								/>
+								<div><Link to={`/crew/${variant.symbol}/`}>{variant.name}</Link></div>
+							</Grid.Column>
+						))}
+					</Grid>
+				</Segment>
+			))
 		);
 	}
 }

--- a/src/components/crewvariants.tsx
+++ b/src/components/crewvariants.tsx
@@ -51,7 +51,7 @@ class CrewVariants extends Component<CrewVariantsProps, CrewVariantsState> {
 						variants.push({'name': found[0].short_name, 'trait_variants': found});
 					}
 				});
-				self.setState({ 'variants': variants });
+				self.setState({ variants });
 			});
 	}
 

--- a/src/templates/crewpage.tsx
+++ b/src/templates/crewpage.tsx
@@ -221,7 +221,7 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 						</Comment.Group>
 							)*/}
 					<Divider horizontal hidden style={{ marginTop: '4em' }} />
-					<CrewVariants short_name={crew.short_name} />
+					<CrewVariants traits_hidden={crew.traits_hidden} />
 				</Container>
 			</Layout>
 		);


### PR DESCRIPTION
1) This will get variants from traits_hidden instead of short_name, thus catching variants with no short_names or misleading short_names (e.g. Douglas Pabst, all Qs), and also crew with multiple possible variants (e.g. Duras Sisters, Data Q).

2) Variants will now be sorted by rarity and name.

3) This will also wrap variants to multiple lines for better responsive design on mobile (4 per row by default, down to 2 on smaller viewports).

This is how Data Q's variants currently look on mobile:

![Screen Shot 2021-01-09 at 16 22 58](https://user-images.githubusercontent.com/76980548/104109810-2e952e00-5297-11eb-87e5-ab923b1b62a2.png)

With this PR, the variants will wrap instead of overlapping (please ignore the broken images; I didn't change my env to show assets properly):

![Screen Shot 2021-01-09 at 16 23 23](https://user-images.githubusercontent.com/76980548/104109818-3d7be080-5297-11eb-8447-c85ff40c4bde.png)

And the second variant group will now follow the first:

![Screen Shot 2021-01-09 at 16 23 30](https://user-images.githubusercontent.com/76980548/104109828-4ff61a00-5297-11eb-9f86-6dfe2f065462.png)