### PR TITLE
Fix voyage calculator to exclude correct event crew when player data contains multiple events

### DIFF
--- a/src/utils/voyageutils.ts
+++ b/src/utils/voyageutils.ts
@@ -268,7 +268,10 @@ export function bonusCrewForCurrentEvent(playerData: any, crewlist: any[]): Bonu
     let result = new BonusCrew();
 
     if (playerData.character.events && playerData.character.events.length > 0) {
-		let activeEvent = playerData.character.events[0];
+        let activeEvent = playerData.character.events
+          .filter((ev) => (ev.seconds_to_end > 0))
+          .sort((a, b) => (a.seconds_to_start - b.seconds_to_start))
+          [0];
         result.eventName = activeEvent.name;
 
         let eventCrew: { [index: string]: any } = {};


### PR DESCRIPTION
Tested this and it all should work correctly.

Assumption: `seconds_to_start` remains a number (either `0` or a negative value) when event has begun, and `seconds_to_end` remains a number (either `0` or negative value) when event has ended. I cannot test this assumption until the next event starts.

There is also a "status" field for the events (currently set to 0 for both), which I assume could also be used to filter, but without knowing the possible values, using `seconds_to_end` feels safer.

Fixes #44.