### PR TITLE
Added options to search for multiple crew and by skill

### DIFF
--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -121,7 +121,7 @@ export class SearchableTable extends PureComponent<SearchableTableProps, Searcha
 
 		if (this.state.searchFilter) {
 			let filters = [];
-			let grouped = this.state.searchFilter.split(/ OR /i);
+			let grouped = this.state.searchFilter.split(/\s+OR\s+/i);
 			grouped.forEach(group => {
 				filters.push(SearchString.parse(group));
 			});

--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -120,8 +120,12 @@ export class SearchableTable extends PureComponent<SearchableTableProps, Searcha
 		let { data } = this.state;
 
 		if (this.state.searchFilter) {
-			let filter = SearchString.parse(this.state.searchFilter);
-			data = data.filter(row => this.props.filterRow(row, filter));
+			let filters = [];
+			let grouped = this.state.searchFilter.split(/ OR /i);
+			grouped.forEach(group => {
+				filters.push(SearchString.parse(group));
+			});
+			data = data.filter(row => this.props.filterRow(row, filters));
 		}
 
 		let totalPages = Math.ceil(data.length / this.state.pagination_rows);

--- a/src/pages/items.tsx
+++ b/src/pages/items.tsx
@@ -79,21 +79,28 @@ class ItemsPage extends Component<ItemsPageProps, ItemsPageState> {
 			});
 	}
 
-	_filterItem(item: any, filter: any): boolean {
+	_filterItem(item: any, filters: []): boolean {
 		const matchesFilter = (input: string, searchString: string) =>
 			input.toLowerCase().indexOf(searchString.toLowerCase()) >= 0;
 
-		let matches = true;
+		let meetsAnyCondition = false;
 
-		if (filter.conditionArray.length === 0) {
-			// text search only
-			for (let segment of filter.textSegments) {
-				let segmentResult = matchesFilter(item.name, segment.text) || matchesFilter(item.flavor, segment.text);
-				matches = matches && (segment.negated ? !segmentResult : segmentResult);
+		for (let filter of filters) {
+			let meetsAllConditions = true;
+			if (filter.conditionArray.length === 0) {
+				// text search only
+				for (let segment of filter.textSegments) {
+					let segmentResult = matchesFilter(item.name, segment.text) || matchesFilter(item.flavor, segment.text);
+					meetsAllConditions = meetsAllConditions && (segment.negated ? !segmentResult : segmentResult);
+				}
+			}
+			if (meetsAllConditions) {
+				meetsAnyCondition = true;
+				break;
 			}
 		}
 
-		return matches;
+		return meetsAnyCondition;
 	}
 
 	renderTableRow(item: any): JSX.Element {
@@ -149,7 +156,7 @@ class ItemsPage extends Component<ItemsPageProps, ItemsPageState> {
 							data={this.state.items}
 							explanation={
 								<div>
-									<p>Do simple text search in the name and flavor</p>
+									<p>Search for items by name or flavor.</p>
 								</div>
 							}
 							renderTableRow={crew => this.renderTableRow(crew)}


### PR DESCRIPTION
Allows shallow OR text searches, e.g. `picard OR torres OR detmer` will return all Picards, Torres, and Detmers (i.e. the event crew from Fireside Stories). Combine search terms for more specific results, e.g. `picard OR torres borg` will return all Picards plus Assimilated Torres, `picard borg OR torres borg` will only return Locutus and Assimilated Torres.

Also added option to search by skill, e.g. `kirk skill:eng` will return only the Kirks with engineering. Skill searches accept full skill names (`command`, `diplomacy`, etc.) or shorts (`cmd`, `dip`, etc).

Updated the Advanced Search tips with OR and skill searching examples, and reworded some other tips. Tried to use examples that demonstrate handling of unusual search terms, like `tpol` (apostrophes) and `trait:"q continuum"` (multiword trait).

Items can similarly be searched for on items page, e.g. `casing OR poly`. Probably not all that useful, but had to change for compatibility with new search filters anyway.