### PR TITLE
List optimal polestar combinations

### DIFF
--- a/src/components/extracrewdetails.tsx
+++ b/src/components/extracrewdetails.tsx
@@ -84,6 +84,7 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 			.then(crew => {
 				// Find all crew who have any polestars in common
 				for (let i = 0; i < crew.length; i++) {
+				  if (!crew[i].in_portal) continue;
 					let polesInCommon = [];
 					for (let t = 0; t < this.props.traits.length; t++) {
 						if (crew[i].traits.indexOf(this.props.traits[t]) >= 0)
@@ -111,10 +112,10 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 				// Find optimal polestars, i.e. combinations with best chance of retrieving this crew
 				polestarCounts.sort((a, b) => {
 					if (a.count == b.count)
-						return a.polestars.length > b.polestars.length;
-					return a.count > b.count;
+						return a.polestars.length - b.polestars.length;
+					return a.count - b.count;
 				});
-				let optimized = [], iBestCount = 5, iMinimumTraits = 4;
+				let optimized = [], iBestCount = 10, iMinimumTraits = 4;
 				for (let i = 0; i < polestarCounts.length; i++) {
 					// Ignore the other counts if worse than best chance or minimum trait count
 					if (polestarCounts[i].count > iBestCount)
@@ -227,7 +228,7 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 	}
 
 	renderPolestars() {
-		if (!this.state.polestars) {
+		if (!this.state.polestars || !this.state.keystone) {
 			return <span />;
 		}
 

--- a/src/components/extracrewdetails.tsx
+++ b/src/components/extracrewdetails.tsx
@@ -4,22 +4,49 @@ import ItemDisplay from '../components/itemdisplay';
 import { Link } from 'gatsby';
 
 type ExtraCrewDetailsProps = {
-	traits_hidden: any[],
-	crew_archetype_id: number
+	crew_archetype_id: number,
+	max_rarity: number,
+	base_skills: any,
+	traits: any[],
+	traits_hidden: any[]
 };
 
 type ExtraCrewDetailsState = {
 	variants: any[],
-	keystone: any
+	keystone: any,
+	polestars: any
 };
 
 class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetailsState> {
 	state = {
 		variants: [],
-		keystone: undefined
+		keystone: undefined,
+		polestars: undefined
 	};
 
 	componentDidMount() {
+		// Prepare polestar counts
+		let polestars = this.props.traits.slice();
+		polestars.push('crew_max_rarity_'+this.props.max_rarity);
+		for (let skill in this.props.base_skills) {
+			if (this.props.base_skills[skill]) polestars.push(skill);
+		}
+		let polestarCounts = [];
+		let f = function(prepoles, traits) {
+			for (let t = 0; t < traits.length; t++) {
+				const newpoles = prepoles.slice();
+				newpoles.push(traits[t]);
+				if (newpoles.length <= 4) {
+					polestarCounts.push({
+						'polestars': newpoles,
+						'count': 0
+					});
+				}
+				f(newpoles, traits.slice(t+1));
+			}
+		}
+		f([], polestars);
+
 		// Get variant names from traits_hidden
 		let ignore = [
 			'tos', 'tas', 'tng', 'ds9', 'voy', 'ent', 'dsc', 'pic',
@@ -37,9 +64,94 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 		}
 
 		let self = this;
+		fetch('/structured/keystones.json')
+			.then(response => response.json())
+			.then(allkeystones => {
+				let crew_keystone_crate = allkeystones.find((k: any) => k.crew_archetype_id === this.props.crew_archetype_id);
+
+				if (crew_keystone_crate) {
+					self.setState({
+						keystone: {
+							name: crew_keystone_crate.name, flavor: crew_keystone_crate.flavor,
+							keystones: crew_keystone_crate.keystones.map((kid: any) => allkeystones.find((k: any) => k.id === kid))
+						}
+					});
+				}
+			});
+
 		fetch('/structured/crew.json')
 			.then(response => response.json())
 			.then(crew => {
+				// Find all crew who have any polestars in common
+				for (let i = 0; i < crew.length; i++) {
+					let polesInCommon = [];
+					for (let t = 0; t < this.props.traits.length; t++) {
+						if (crew[i].traits.indexOf(this.props.traits[t]) >= 0)
+							polesInCommon.push(this.props.traits[t]);
+					}
+					// Add 1 to count of every polestar combination in common
+					if (polesInCommon.length > 0) {
+						if (crew[i].max_rarity == this.props.max_rarity)
+							polesInCommon.push('crew_max_rarity_'+this.props.max_rarity);
+						for (let skill in crew[i].base_skills) {
+							if (crew[i].base_skills[skill] && this.props.base_skills[skill])
+								polesInCommon.push(skill);
+						}
+						polestarCounts.forEach(count => {
+							if (polesInCommon.length >= count.polestars.length) {
+								let bMatching = true;
+								count.polestars.forEach(polestar => {
+									bMatching = bMatching && polesInCommon.indexOf(polestar) >= 0;
+								});
+								if (bMatching) count.count++;
+							}
+						});
+					}
+				}
+				// Find optimal polestars, i.e. combinations with best chance of retrieving this crew
+				polestarCounts.sort((a, b) => {
+					if (a.count == b.count)
+						return a.polestars.length > b.polestars.length;
+					return a.count > b.count;
+				});
+				let optimized = [], iBestCount = 5, iMinimumTraits = 4;
+				for (let i = 0; i < polestarCounts.length; i++) {
+					// Ignore the other counts if worse than best chance or minimum trait count
+					if (polestarCounts[i].count > iBestCount)
+						break;
+					if (iMinimumTraits < 4 && polestarCounts[i].polestars.length == 4)
+						break;
+
+					if (polestarCounts[i].count > 5) continue;	// Only a maximum of 4 polestars are allowed
+					if (polestarCounts[i].count < iBestCount)
+						iBestCount = polestarCounts[i].count;
+					if (polestarCounts[i].polestars.length < iMinimumTraits)
+						iMinimumTraits = polestarCounts[i].polestars.length;
+
+					let bInclude = true;
+					let polestars = polestarCounts[i].polestars;
+					// Do not include redundant combinations
+					//	(i.e. combos w/ 4 polestars that aren't better than similar 3 polestar combos)
+					optimized.forEach(count => {
+						if (polestars.length >= count.polestars.length) {
+							let bMatching = true;
+							count.polestars.forEach(polestar => {
+								bMatching = bMatching && polestars.indexOf(polestar) >= 0;
+							});
+							if (bMatching && polestarCounts[i].count <= count.count) {
+								bInclude = false;
+							}
+						}
+					});
+					if (bInclude)
+						optimized.push({
+							'polestars': polestarCounts[i].polestars,
+							'chance': (1/polestarCounts[i].count*100).toFixed()
+						});
+				}
+				self.setState({ polestars: optimized });
+
+				// Get variants
 				let variants = [];
 				variantTraits.forEach(function (trait) {
 					let found = crew.filter(c => c.traits_hidden.indexOf(trait) >= 0);
@@ -55,21 +167,6 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 					}
 				});
 				self.setState({ variants });
-			});
-
-		fetch('/structured/keystones.json')
-			.then(response => response.json())
-			.then(allkeystones => {
-				let crew_keystone_crate = allkeystones.find((k: any) => k.crew_archetype_id === this.props.crew_archetype_id);
-
-				if (crew_keystone_crate) {
-					self.setState({
-						keystone: {
-							name: crew_keystone_crate.name, flavor: crew_keystone_crate.flavor,
-							keystones: crew_keystone_crate.keystones.map((kid: any) => allkeystones.find((k: any) => k.id === kid))
-						}
-					});
-				}
 			});
 	}
 
@@ -129,6 +226,48 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 		);
 	}
 
+	renderPolestars() {
+		if (!this.state.polestars) {
+			return <span />;
+		}
+
+		const { polestars } = this.state;
+
+		return (
+			<Segment>
+				<Header as='h4'>Optimal Polestars for Crew Retrieval</Header>
+				<Table celled selectable striped collapsing unstackable compact='very'>
+					<Table.Header>
+						<Table.Row>
+							<Table.HeaderCell width={1}>Best Chance</Table.HeaderCell>
+							<Table.HeaderCell width={3}>Polestar Combination</Table.HeaderCell>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{polestars.map(chance => (
+							<Table.Row>
+								<Table.Cell>
+									<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}>
+										{chance.chance}%
+									</span>
+								</Table.Cell>
+								<Table.Cell>
+									<Grid centered padded>
+									{chance.polestars.map((polestar, idx) => (
+										<Grid.Column key={idx} textAlign='center' mobile={8} tablet={5} computer={4}>
+											<div>{polestar}</div>
+										</Grid.Column>
+									))}
+									</Grid>
+								</Table.Cell>
+							</Table.Row>
+						))}
+					</Table.Body>
+				</Table>
+			</Segment>
+		);
+	}
+
 	renderVariants() {
 		if (this.state.variants.length == 0) {
 			return <span />;
@@ -159,6 +298,7 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 	render() {
 		return <div>
 			{this.renderKeystone()}
+			{this.renderPolestars()}
 			{this.renderVariants()}
 		</div>;
 	}

--- a/src/components/extracrewdetails.tsx
+++ b/src/components/extracrewdetails.tsx
@@ -122,7 +122,7 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 					if (iMinimumTraits < 4 && polestarCounts[i].polestars.length == 4)
 						break;
 
-					if (polestarCounts[i].count > 5) continue;	// Only a maximum of 4 polestars are allowed
+					if (polestarCounts[i].length > 5) continue;	// Only a maximum of 4 polestars are allowed
 					if (polestarCounts[i].count < iBestCount)
 						iBestCount = polestarCounts[i].count;
 					if (polestarCounts[i].polestars.length < iMinimumTraits)

--- a/src/templates/crewpage.tsx
+++ b/src/templates/crewpage.tsx
@@ -221,7 +221,12 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 						</Comment.Group>
 							)*/}
 					<Divider horizontal hidden style={{ marginTop: '4em' }} />
-					<ExtraCrewDetails traits_hidden={crew.traits_hidden} crew_archetype_id={crew.archetype_id} />
+					<ExtraCrewDetails
+						crew_archetype_id={crew.archetype_id}
+						max_rarity={crew.max_rarity}
+						base_skills={crew.base_skills}
+						traits={crew.traits} traits_hidden={crew.traits_hidden}
+					/>
 				</Container>
 			</Layout>
 		);
@@ -398,6 +403,7 @@ export const query = graphql`
 					series
 					symbol
 					archetype_id
+					traits
 					traits_named
 					traits_hidden
 					collections


### PR DESCRIPTION
This identifies the polestar combinations that give the best chance at getting a specified crew from crew retrieval. Right now it favors combinations with the fewest polestars as possible, though for some crew it's still a pretty big list.

Note that this isn't very pretty and there are likely more efficient or more useful ways to do this. We could possibly simplify the constellation section on the crew page and combine the optimal polestars with that. Any advice on improving this are welcome!