### PR TITLE
Use traits_named, fix supersets

### DIFF
--- a/src/templates/crewpage.tsx
+++ b/src/templates/crewpage.tsx
@@ -225,7 +225,7 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 						crew_archetype_id={crew.archetype_id}
 						max_rarity={crew.max_rarity}
 						base_skills={crew.base_skills}
-						traits={crew.traits} traits_hidden={crew.traits_hidden}
+						traits_named={crew.traits_named} traits_hidden={crew.traits_hidden}
 					/>
 				</Container>
 			</Layout>


### PR DESCRIPTION
Bunch of fixes here including:

Use `traits_named` instead of `traits` to avoid stale trait names (e.g. "physician" instead of "doctor"). Rarity and skills now also use Proper Names instead of symbols, for consistency.

Keystones list now use `short_name` instead of `filter.trait` to similarly avoid stale trait names. (TODO: Check on how `filter.trait` is generated in structured/keystones.json)

Supersets of more optimal subsets are now properly ignored (e.g. Warship EMA's "federation, interrogator, android" won't be listed since "interrogator, android" is already listed).

Cleaned up some code, renamed a few variables and added more comments for clarification, rewrote the optimal check loop to break out early whenever possible.