### PR TITLE
Add crew pseudocolumns and ability filter on portal status

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -79,6 +79,8 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 						let skillShort = CONFIG.SKILLS_SHORT.find(skill => skill.short === condition.value.toUpperCase());
 						let skillName = skillShort ? skillShort.name : condition.value.toLowerCase()+"_skill";
 						conditionResult = skillName in crew.base_skills;
+					} else if (condition.keyword === 'in_portal') {
+						conditionResult = condition.value.toLowerCase() === 'true' ? crew.in_portal : !crew.in_portal;
 					}
 					meetsAllConditions = meetsAllConditions && (condition.negated ? !conditionResult : conditionResult);
 				}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ type IndexPageState = {
 };
 
 const tableConfig: ITableConfigRow[] = [
-	{ width: 3, column: 'name', title: 'Crew' },
+	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
 	{ width: 1, column: 'max_rarity', title: 'Rarity' },
 	{ width: 1, column: 'command_skill', title: 'Command' },
 	{ width: 1, column: 'science_skill', title: 'Science' },


### PR DESCRIPTION
This brings us one step closer to making the crew_profile component use SearchableTable, adds functionality to the main crew table, and facilitates the workflow envisioned in #66 (as you will now be able to search for `trait:android in_portal:true` and then sort by tier).