### PR TITLE
Fix ship level display in player utils

### DIFF
--- a/src/utils/shiputils.ts
+++ b/src/utils/shiputils.ts
@@ -85,7 +85,7 @@ export function mergeShips(ship_schematics: any, ships: any): any {
 			schematic.ship.crit_chance = owned.crit_chance;
 			schematic.ship.evasion = owned.evasion;
 			schematic.ship.hull = owned.hull;
-			schematic.ship.level = owned.level;
+			schematic.ship.level = owned.level + 1;
 			schematic.ship.rarity = owned.rarity;
 			schematic.ship.shield_regen = owned.shield_regen;
 			schematic.ship.shields = owned.shields;
@@ -94,6 +94,8 @@ export function mergeShips(ship_schematics: any, ships: any): any {
 			schematic.ship.level = 0;
 			schematic.ship.owned = false;
 		}
+		
+		schematic.ship.max_level += 1;
 
 		schematic.ship.traits_named = traits_named;
 


### PR DESCRIPTION
This has been a long-standing display glitch, which has shown the levels of owned ships always by 1 lower than they should be.

To clarify: all ship data from the `player.json` game export as well as the `ship_schematics.json` start counting levels at 0 (to a maximum of 9 for a 5* ship). This has resulted in ships being shown as level 9 / 9 when they are maxed, but more importantly owned 1 / 10 and un-owned 0 / 10 ships have both been erroneously displayed as 0 / 9.