### PR TITLE
Simplifies constellation view, adds icons, alts to optimal polestars

### DIFF
--- a/src/templates/crewpage.tsx
+++ b/src/templates/crewpage.tsx
@@ -225,7 +225,8 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 						crew_archetype_id={crew.archetype_id}
 						max_rarity={crew.max_rarity}
 						base_skills={crew.base_skills}
-						traits_named={crew.traits_named} traits_hidden={crew.traits_hidden}
+						traits={crew.traits} traits_hidden={crew.traits_hidden}
+						unique_polestar_combos={crew.unique_polestar_combos}
 					/>
 				</Container>
 			</Layout>
@@ -519,6 +520,7 @@ export const query = graphql`
 						crit_chance
 						evasion
 					}
+					unique_polestar_combos
 				}
 			}
 		}


### PR DESCRIPTION
On the crew page, this simplifies the constellation details into a grid of polestar icons rather than a table with polestar icons and flavors.

Optimal polestars now use icons instead of just text. Additionally if a crew has a non-100% chance of being retrieved, the chance also lists the alternate crew members that might be retrieved with the same polestar combination.

Optimal polestars now use the precalculated list of unique combos if it exists. Otherwise it will generate the best chance combos on demand, as before.

Adds a small description to optimal polestars: "The best chance to retrieve this crew using as few polestars as possible"