### PR TITLE
Workaround: avoid broken sort order when filtering polestars

### DIFF
--- a/src/components/crewretrieval.tsx
+++ b/src/components/crewretrieval.tsx
@@ -294,7 +294,8 @@ class CrewRetrieval extends Component<CrewRetrievalProps, CrewRetrievalState> {
 		if(e.target.checked === false && this.state.disabledPolestars.indexOf(id) === -1) {
 			disabledPolestars.push(id);
 		}
-		this.setState({disabledPolestars: disabledPolestars});
+		// temp. workaround: avoid broken sort order when data is recreated with filtered polestars
+		this.setState({column: null, direction: null, disabledPolestars: disabledPolestars});
 	}
 
 	render() {


### PR DESCRIPTION
Bug reported by James 'Lucian' Wix on Discord.

![image](https://user-images.githubusercontent.com/65423314/110209733-51eeea80-7e8e-11eb-8f44-80c4ec072542.png)

When using the filter feature to disable polestars, the `this.state.data` array is recreated and does not preserve any previous sort order.

This is only a temporary workaround, which disables any previously set column sort to avoid breaking the sort functionality (clicking on the same column again only reverses the wrong sort order).

I'm hesitant to modify the `_handleSort()` method in `crewretrieval.tsx` at this time, because there are various copies of it spread around different components.