### PR TITLE
Player Tools refactor - new files only

### DIFF
--- a/src/components/unneededitems.tsx
+++ b/src/components/unneededitems.tsx
@@ -1,0 +1,167 @@
+import React, { Component } from 'react';
+import { Header, Message, Grid, Icon } from 'semantic-ui-react';
+
+import ItemDisplay from '../components/itemdisplay';
+import { mergeItems } from '../utils/itemutils';
+import { mergeShips } from '../utils/shiputils';
+
+
+type UnneededItemsProps = {
+	playerData: any;
+};
+
+type UnneededItemsState = {
+	fuelschematics: any[];
+	fuelspecific: any[];
+	fuelgeneric: any[];
+};
+
+class UnneededItems extends Component<UnneededItemsProps, UnneededItemsState> {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			fuelschematics: [],
+			fuelspecific: [],
+			fuelgeneric: []
+		};
+	}
+
+	async componentDidMount() {
+		const { playerData } = this.props;
+
+		const [itemsResponse, shipsResponse] = await Promise.all([
+			fetch('/structured/items.json'),
+			fetch('/structured/ship_schematics.json')
+		]);
+
+		const allitems = await itemsResponse.json();
+		const allships = await shipsResponse.json();
+
+		let items = mergeItems(playerData.player.character.items, allitems);
+		let ships = mergeShips(allships, playerData.player.character.ships);
+
+		// Calculate unneeded schematics
+		let maxedShips = ships.filter(
+			ship => ship.level === ship.max_level
+		);
+		let fuelschematics = items.filter(
+			item => maxedShips.some((ship) => {
+				if (ship.symbol+'_schematic' === item.symbol) {
+					item.rarity = ship.rarity;	// Use ship rarity instead of schematic item rarity
+					return true;
+				}
+			})
+		);
+
+		// Calculate all replicator fodder
+		// 	Only consider equipment of already immortalized crew as fodder
+		//	This may miss out on items for crew who are mid-level (or even fully equipped Lvl 99s)
+		let equipmentAlreadyOnCrew = new Set();
+		let equipmentNeededByCrew = new Set();
+		playerData.player.character.crew.forEach(crew => {
+			crew.equipment_slots.forEach(equipment => {
+				if (crew.immortal > 0)
+					equipmentAlreadyOnCrew.add(equipment.symbol);
+				else
+					equipmentNeededByCrew.add(equipment.symbol);
+			});
+		});
+		let fuellist = items.filter(
+			item => equipmentAlreadyOnCrew.has(item.symbol) &&
+					!equipmentNeededByCrew.has(item.symbol)
+		);
+
+		// Should probably regex this
+		//	Fancy apostrophe check needed for some crew
+		const isSpecificItem = (name) =>
+			name.indexOf("'s ") > 0 ||
+			name.indexOf("s' ") > 0 ||
+			name.indexOf("’s ") > 0 ||
+			name.indexOf("s’ ") > 0;
+
+		// Filter crew-specific items
+		let fuelspecific = fuellist.filter(
+			item => isSpecificItem(item.name)
+		);
+
+		// Filter generic items
+		let fuelgeneric = fuellist.filter(
+			item =>
+				item.quantity === 1 && item.rarity > 1 &&
+				!isSpecificItem(item.name)
+		);
+
+		this.setState({ fuelschematics, fuelspecific, fuelgeneric });
+	}
+
+	render() {
+		const { playerData } = this.props;
+
+		let itemCount = playerData.player.character.items.length;
+		let itemLimit = 1000, itemWarning = .9*itemLimit;
+		// Hardcoded limit works now, but if the game increases limit, we'll have to update
+		//	We should get this from playerData.player.character.item_limit, but it's not in preparedProfileData
+
+		return (
+			<div>
+				{itemCount > itemWarning && (
+					<Message warning>
+						<Message.Header>Items approaching limit</Message.Header>
+						<p>
+							You have {itemCount} items in your inventory. At {itemLimit} the game starts randomly losing
+							items; go and replicate away some unnecessary stuff.
+						</p>
+					</Message>
+				)}
+
+				<Header as='h4'>Here are {this.state.fuelschematics.length} items that you don't need (used to upgrade ships you already maxed):</Header>
+				<Grid columns={5} centered padded>
+					{this.state.fuelschematics.map((item, idx) => (
+						<Grid.Column key={idx} rel={item.archetype_id} textAlign='center'>
+							<ItemDisplay
+								src={`${process.env.GATSBY_ASSETS_URL}${item.imageUrl}`}
+								size={64}
+								maxRarity={item.rarity}
+								rarity={item.rarity}
+							/>
+							<p>{item.name}</p>
+						</Grid.Column>
+					))}
+				</Grid>
+
+				<Header as='h4'>Here are {this.state.fuelspecific.length} items that you don't need (used to equip specific crew you already equipped):</Header>
+				<Grid columns={5} centered padded>
+					{this.state.fuelspecific.map((item, idx) => (
+						<Grid.Column key={idx} rel={item.archetype_id} textAlign='center'>
+							<ItemDisplay
+								src={`${process.env.GATSBY_ASSETS_URL}${item.imageUrl}`}
+								size={64}
+								maxRarity={item.rarity}
+								rarity={item.rarity}
+							/>
+							<p>{item.name}</p>
+						</Grid.Column>
+					))}
+				</Grid>
+
+				<Header as='h4'>Here are {this.state.fuelgeneric.length} items that you don't need now, but might be useful in the future:</Header>
+				<Grid columns={5} centered padded>
+					{this.state.fuelgeneric.map((item, idx) => (
+						<Grid.Column key={idx} rel={item.archetype_id} textAlign='center'>
+							<ItemDisplay
+								src={`${process.env.GATSBY_ASSETS_URL}${item.imageUrl}`}
+								size={64}
+								maxRarity={item.rarity}
+								rarity={item.rarity}
+							/>
+							<p>{item.name}</p>
+						</Grid.Column>
+					))}
+				</Grid>
+			</div>
+		);
+	}
+}
+
+export default UnneededItems;

--- a/src/components/voyagecalculator_iap.tsx
+++ b/src/components/voyagecalculator_iap.tsx
@@ -1,0 +1,419 @@
+import React, { Component } from 'react';
+import { Header, Button, Message, Grid, Icon, Form, Tab, Select, Dropdown, Checkbox, Modal, Image, Segment } from 'semantic-ui-react';
+import ItemDisplay from '../components/itemdisplay';
+import {
+	ICalcResult,
+	calculateVoyage,
+	formatTimeSeconds,
+	BonusCrew
+} from '../utils/voyageutils';
+
+import { applyCrewBuffs} from '../utils/crewutils';
+import { mergeShips } from '../utils/shiputils';
+
+import CrewPopup from '../components/crewpopup';
+
+import CONFIG from './CONFIG';
+
+type VoyageCalculatorProps = {
+	playerData: any;
+	voyageData: any;
+	eventData: any;
+};
+
+enum CalculatorState {
+	NotStarted,
+	InProgress,
+	Done
+}
+
+type VoyageCalculatorState = {
+	bestShip: any;
+	calcState: CalculatorState;
+	crew: any[];
+	result?: ICalcResult;
+	includeFrozen: boolean;
+	includeActive: boolean;
+	activeEvent: string | undefined;
+	peopleList: any;
+	currentSelection: any[];
+	searchDepth: number;
+	extendsTarget: number;
+};
+
+class VoyageCalculator extends Component<VoyageCalculatorProps, VoyageCalculatorState> {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			bestShip: undefined,
+			calcState: CalculatorState.NotStarted,
+			crew: [],
+			result: undefined,
+			includeFrozen: false,
+			includeActive: false,
+			peopleList: undefined,
+			currentSelection: [],
+			activeEvent: undefined,
+			searchDepth: 6,
+			extendsTarget: 0
+		};
+	}
+
+	async componentDidMount() {
+		const { playerData, voyageData, eventData } = this.props;
+
+		const [shipsResponse] = await Promise.all([
+			fetch('/structured/ship_schematics.json')
+		]);
+		const allships = await shipsResponse.json();
+
+		let ships = mergeShips(allships, playerData.player.character.ships);
+		let bestShips = this._bestVoyageShip(ships, voyageData);
+
+		let shuttleCrew = JSON.parse(JSON.stringify(voyageData.shuttle_crew));
+
+		let crewlist = [];
+		let peopleListDefault = [], peopleListAll = [];
+		let fakeID = 1;
+
+		playerData.player.character.crew.forEach(crew => {
+			let crewman = JSON.parse(JSON.stringify(crew));
+			crewman.id = fakeID++;
+
+			// Voyage calculator looks for skills, range_min, range_max properties
+			let skills = {};
+			for (let skill in CONFIG.SKILLS) {
+				if (crew[skill].core > 0)
+					skills[skill] = {
+						'core': crew[skill].core,
+						'range_min': crew[skill].min,
+						'range_max': crew[skill].max
+					};
+			}
+			crewman.skills = skills;
+
+			// Voyage roster generation looks for active_id property
+			crewman.active_id = 0;
+			if (crew.immortal === 0) {
+				let shuttleCrewId = crew.symbol+','+crew.level+','+crew.equipment.join('');
+				let shuttleIndex = shuttleCrew.indexOf(shuttleCrewId);
+				if (shuttleIndex >= 0) {
+					crewman.active_id = 1;
+					shuttleCrew[shuttleIndex] = '';	// Clear this ID so that dupes are counted properly
+				}
+			}
+
+			crewlist.push(crewman);
+
+			// Populate exclusion lists
+			let person = {
+				key: crewman.id,
+				value: crewman.id,
+				image: { avatar: true, src: `${process.env.GATSBY_ASSETS_URL}${crewman.imageUrlPortrait}` },
+				text: crewman.name
+			};
+			peopleListAll.push(person);
+			if (crew.immortal === 0) peopleListDefault.push(person);
+		});
+
+		let peopleList = {
+			'all': peopleListAll.sort((a, b) => a.text.localeCompare(b.text)),
+			'default': peopleListDefault.sort((a, b) => a.text.localeCompare(b.text))
+		};
+
+		let bonusCrew = this._bonusCrewForCurrentEvent(eventData, crewlist);
+		if (bonusCrew) {
+			this.setState({ activeEvent: bonusCrew.eventName, currentSelection: bonusCrew.crewIds });
+		}
+
+		this.setState({ bestShip: bestShips[0], crew: crewlist, peopleList });
+	}
+
+	render() {
+		const { playerData, voyageData } = this.props;
+		const { bestShip, crew } = this.state;
+
+		if (!bestShip)
+			return (<></>);
+
+		let curVoy = '';
+		let currentVoyage = false;
+		if (voyageData.voyage_descriptions && voyageData.voyage_descriptions.length > 0) {
+			curVoy = `${CONFIG.SKILLS[voyageData.voyage_descriptions[0].skills.primary_skill]} primary / ${
+				CONFIG.SKILLS[voyageData.voyage_descriptions[0].skills.secondary_skill]
+			} secondary`;
+		}
+		if (voyageData.voyage && voyageData.voyage.length > 0) {
+			curVoy = `${CONFIG.SKILLS[voyageData.voyage[0].skills.primary_skill]} primary / ${
+				CONFIG.SKILLS[voyageData.voyage[0].skills.secondary_skill]
+			} secondary`;
+			currentVoyage = voyageData.voyage[0].state === 'started';
+		}
+
+		let peopleListStyle = this.state.includeFrozen ? 'all' : 'default';
+
+		return (
+			<div style={{ margin: '5px' }}>
+				{currentVoyage && <p>It looks like you already have a voyage started!</p>}
+				<Message attached>
+					VOYAGE CALCULATOR! Configure the settings below, then click on the "Calculate" button to see the recommendations. Current voyage
+					is <b>{curVoy}</b>.
+				</Message>
+				<Form className='attached fluid segment'>
+					<Form.Group inline>
+						<Form.Field
+							control={Select}
+							label='Search depth'
+							options={[
+								{ key: '4', text: '4 (fastest)', value: 4 },
+								{ key: '5', text: '5 (faster)', value: 5 },
+								{ key: '6', text: '6 (normal)', value: 6 },
+								{ key: '7', text: '7 (slower)', value: 7 },
+								{ key: '8', text: '8 (slowest)', value: 8 },
+								{ key: '9', text: '9 (for supercomputers)', value: 9 }
+							]}
+							value={this.state.searchDepth}
+							onChange={(e, { value }) => this.setState({ searchDepth: value })}
+							placeholder='Search depth'
+						/>
+						<Form.Field
+							control={Select}
+							label='Extends (target)'
+							options={[
+								{ key: '0', text: 'none (default)', value: 0 },
+								{ key: '1', text: 'one', value: 1 },
+								{ key: '2', text: 'two', value: 2 }
+							]}
+							value={this.state.extendsTarget}
+							onChange={(e, { value }) => this.setState({ extendsTarget: value })}
+							placeholder='How many times you plan to revive'
+						/>
+					</Form.Group>
+
+					<Form.Group inline>
+						<Form.Field>
+							<label>Best ship</label>
+							<b>
+								{bestShip.ship.name} ({bestShip.score} Antimatter)
+							</b>
+						</Form.Field>
+					</Form.Group>
+
+					<Form.Group>
+						<Form.Field
+							control={Dropdown}
+							clearable
+							fluid
+							multiple
+							search
+							selection
+							options={this.state.peopleList[peopleListStyle]}
+							placeholder='Select or search for crew'
+							label={
+								"Crew you don't want to consider for voyage" +
+								(this.state.activeEvent ? ` (preselected crew which gives bonus in the event ${this.state.activeEvent})` : '')
+							}
+							value={this.state.currentSelection}
+							onChange={(e, { value }) => this.setState({ currentSelection: value })}
+						/>
+					</Form.Group>
+
+					<Form.Group inline>
+						<Form.Field
+							control={Checkbox}
+							label='Consider active (on shuttles) crew'
+							checked={this.state.includeActive}
+							onChange={(e, { checked }) => this.setState({ includeActive: checked })}
+						/>
+
+						<Form.Field
+							control={Checkbox}
+							label='Consider frozen (vaulted) crew'
+							checked={this.state.includeFrozen}
+							onChange={(e, { checked }) => this.setState({ includeFrozen: checked })}
+						/>
+					</Form.Group>
+
+					{this.state.result && (
+						<React.Fragment>
+							<p>
+								Estimated duration: <b>{formatTimeSeconds(this.state.result.score * 60 * 60)}</b>
+							</p>
+							<ul>
+								{this.state.result.entries.map((entry, idx) => {
+									let pcrew = crew.find(c => c.id === entry.choice);
+									let acrew = playerData.player.character.crew.find(c => c.symbol === pcrew.symbol);
+									return (
+										<li key={idx}>
+											{voyageData.voyage_descriptions[0].crew_slots[entry.slotId].name}
+											{'  :  '}
+											<CrewPopup crew={acrew} />
+										</li>
+									);
+								})}
+							</ul>
+						</React.Fragment>
+					)}
+
+					<Form.Group>
+						<Form.Button
+							primary
+							onClick={() => this._calcVoyageData(bestShip.score)}
+							disabled={this.state.calcState === CalculatorState.InProgress}>
+							Calculate best crew selection
+						</Form.Button>
+					</Form.Group>
+				</Form>
+				<Modal basic size='tiny' open={this.state.calcState === CalculatorState.InProgress}>
+                    <Modal.Content image>
+                        <Image centered src='/media/voyage-wait-icon.gif' />
+                    </Modal.Content>
+                    <Modal.Description>
+                        <Segment basic textAlign={"center"}>
+                            <Button onClick={e => this.setState({calcState : CalculatorState.Done})}>Abort</Button>
+                        </Segment>
+                    </Modal.Description>
+                </Modal>
+			</div>
+		);
+	}
+
+	_bestVoyageShip(ships: any[], voyageData: any): any[] {
+		let voyage = voyageData.voyage_descriptions[0];
+
+		let consideredShips: any[] = [];
+		ships.forEach((ship: any) => {
+			let entry = {
+				ship: ship,
+				score: ship.antimatter
+			};
+
+			if (ship.traits.find((trait: any) => trait == voyage.ship_trait)) {
+				entry.score += 150; // TODO: where is this constant coming from (Config)?
+			}
+
+			consideredShips.push(entry);
+		});
+
+		consideredShips = consideredShips.sort((a, b) => b.score - a.score);
+
+		return consideredShips;
+	}
+
+	_bonusCrewForCurrentEvent(eventData: any[], crewlist: any[]): BonusCrew | undefined {
+		if (!eventData || eventData.length == 0)
+			return undefined;
+
+		let activeEvents = eventData.filter((ev) => (ev.seconds_to_end > 0 && ev.seconds_to_start < 86400));
+		if (activeEvents.length == 0)
+			return undefined;
+
+		let activeEvent = activeEvents.sort((a, b) => (a.seconds_to_start - b.seconds_to_start))[0];
+
+		let result = new BonusCrew();
+		result.eventName = activeEvent.name;
+
+		let eventCrew: { [index: string]: any } = {};
+		if (activeEvent.content) {
+			if (activeEvent.content.crew_bonuses) {
+				for (let symbol in activeEvent.content.crew_bonuses) {
+					eventCrew[symbol] = activeEvent.content.crew_bonuses[symbol];
+				}
+			}
+
+			// For skirmish events
+			if (activeEvent.content.bonus_crew) {
+				for (let symbol in activeEvent.content.bonus_crew) {
+					eventCrew[symbol] = activeEvent.content.bonus_crew[symbol];
+				}
+			}
+
+			// For expedition events
+			if (activeEvent.content.special_crew) {
+				activeEvent.content.special_crew.forEach((symbol: string) => {
+					eventCrew[symbol] = symbol;
+				});
+			}
+
+			// TODO: there's also bonus_traits; should we bother selecting crew with those? It looks like you can use voyage crew in skirmish events, so it probably doesn't matter
+			if (activeEvent.content.shuttles) {
+				activeEvent.content.shuttles.forEach((shuttle: any) => {
+					for (let symbol in shuttle.crew_bonuses) {
+						eventCrew[symbol] = shuttle.crew_bonuses[symbol];
+					}
+				});
+			}
+		}
+
+		for (let symbol in eventCrew) {
+			let foundCrew = crewlist.find((crew: any) => crew.have && (crew.symbol === symbol));
+			if (foundCrew) {
+				result.crewIds.push(foundCrew.crew_id || foundCrew.id);
+			}
+		}
+
+		return result;
+	}
+
+	_packVoyageOptions(shipAM: number) {
+		const { voyageData } = this.props;
+		const { crew } = this.state;
+
+		let filteredRoster = crew.filter(crewman => {
+			// Filter out buy-back crew
+			if (crewman.buyback) {
+				return false;
+			}
+
+			if (!this.state.includeActive && crewman.active_id > 0) {
+				return false;
+			}
+
+			if (!this.state.includeFrozen && crewman.immortal > 0) {
+				return false;
+			}
+
+			// Filter out crew the user has chosen not to include
+			if (this.state.currentSelection.length > 0 && this.state.currentSelection.some(ignored => ignored === (crewman.crew_id || crewman.id))) {
+				return false;
+			}
+
+			return true;
+		});
+
+		return {
+			searchDepth: this.state.searchDepth,
+			extendsTarget: this.state.extendsTarget,
+			shipAM: shipAM,
+			skillPrimaryMultiplier: 3.5,
+			skillSecondaryMultiplier: 2.5,
+			skillMatchingMultiplier: 1.1,
+			traitScoreBoost: 200,
+			voyage_description: voyageData.voyage_descriptions[0],
+			roster: filteredRoster
+		};
+	}
+
+	_calcVoyageData(shipAM: number) {
+		let options = this._packVoyageOptions(shipAM);
+
+		calculateVoyage(
+			options,
+			calcResult => {
+				this.setState({
+					result: calcResult,
+					calcState: CalculatorState.InProgress
+				});
+			},
+			calcResult => {
+				this.setState({
+					result: calcResult,
+					calcState: CalculatorState.Done
+				});
+			}
+		);
+	}
+}
+
+export default VoyageCalculator;

--- a/src/pages/playertools.tsx
+++ b/src/pages/playertools.tsx
@@ -1,0 +1,458 @@
+import React, { Component } from 'react';
+import { Container, Header, Message, Tab, Icon, Dropdown, Menu, Button, Form, TextArea, Modal } from 'semantic-ui-react';
+
+import Layout from '../components/layout';
+import ProfileCrew from '../components/profile_crew';
+import ProfileCrewMobile from '../components/profile_crew2';
+import ProfileShips from '../components/profile_ships';
+import ProfileItems from '../components/profile_items';
+import ProfileOther from '../components/profile_other';
+import ProfileCharts from '../components/profile_charts';
+
+import VoyageCalculator from '../components/voyagecalculator_iap';
+import CrewRetrieval from '../components/crewretrieval';
+import UnneededItems from '../components/unneededitems';
+
+import { exportCrew, downloadData, prepareProfileData } from '../utils/crewutils';
+import { stripPlayerData } from '../utils/playerutils';
+
+type PlayerToolsPageProps = {};
+
+type PlayerToolsPageState = {
+	playerData?: any;
+	inputPlayerData?: any;
+	strippedPlayerData?: any;
+	errorMessage?: string;
+	fullInput: string | number;
+	displayedInput: string | number;
+	profileUploading: boolean;
+	profileUploaded: boolean;
+	voyageData?: any;
+	eventData?: any;
+};
+
+const PLAYERLINK = 'https://stt.disruptorbeam.com/player?client_api=17';
+
+const asyncSessionStorage = {
+	setItem: async function (key, value) {
+		await null;
+		return sessionStorage.setItem(key, value);
+	},
+	getItem: async function (key) {
+		await null;
+		return sessionStorage.getItem(key);
+	},
+	clear: async function () {
+		await null;
+		return sessionStorage.clear();
+	}
+};
+
+class PlayerToolsPage extends Component<PlayerToolsPageProps, PlayerToolsPageState> {
+	constructor(props: PlayerToolsPageProps) {
+		super(props);
+
+		this.state = {
+			playerData: undefined,
+			inputPlayerData: undefined,
+			strippedPlayerData: undefined,
+			errorMessage: undefined,
+			fullInput: '',
+			displayedInput: '',
+			profileUploading: false,
+			profileUploaded: false,
+			voyageData: undefined,
+			eventData: undefined
+		};
+	}
+
+	async componentDidMount() {
+		let strippedPlayerData = await asyncSessionStorage.getItem('playerData');
+		if (strippedPlayerData) {
+			let voyageData = await asyncSessionStorage.getItem('voyageData');
+			let eventData = await asyncSessionStorage.getItem('eventData');
+			strippedPlayerData = JSON.parse(strippedPlayerData);
+			if (voyageData) voyageData = JSON.parse(voyageData);
+			if (eventData) eventData = JSON.parse(eventData);
+			this.setState({ strippedPlayerData, voyageData, eventData });
+		}
+	}
+
+	componentDidUpdate() {
+		if (!this.state.playerData && this.state.inputPlayerData)
+			this._prepareProfileDataFromInput();
+		else if (!this.state.playerData && this.state.strippedPlayerData) {
+			this._prepareProfileDataFromSession();
+		}
+	}
+
+	async _prepareProfileDataFromInput() {
+		const { inputPlayerData } = this.state;
+
+		const [crewResponse, itemsResponse] = await Promise.all([
+			fetch('/structured/crew.json'),
+			fetch('/structured/items.json')
+		]);
+
+		const allcrew = await crewResponse.json();
+		const allitems = await itemsResponse.json();
+
+		// Crew on shuttles, voyage data, and event data will be stripped from playerData,
+		//	so keep a copy for voyage calculator here
+		//	Event data is not player-specific, so we should find a way to get that outside of playerData
+		let shuttleCrew = [];
+		inputPlayerData.player.character.crew.forEach(crew => {
+			if (crew.active_id > 0) {
+				// Stripped data doesn't include crewId, so create pseudoId based on level and equipment
+				let shuttleCrewId = crew.symbol+','+crew.level+',';
+				crew.equipment.forEach(equipment => shuttleCrewId += equipment[0]);
+				shuttleCrew.push(shuttleCrewId);
+			}
+		});
+		let voyageData = {
+			voyage_descriptions: JSON.parse(JSON.stringify(inputPlayerData.player.character.voyage_descriptions)),
+			voyage: JSON.parse(JSON.stringify(inputPlayerData.player.character.voyage)),
+			shuttle_crew: shuttleCrew
+		}
+		let eventData = JSON.parse(JSON.stringify(inputPlayerData.player.character.events));
+
+		let dtImported = new Date();
+
+		// strippedPlayerData is used for any storage purpose, i.e. sharing profile and keeping in session
+		let strippedPlayerData = stripPlayerData(allitems, JSON.parse(JSON.stringify(inputPlayerData)));
+		strippedPlayerData.calc = { 'lastImported': dtImported };
+
+		// preparedProfileData is expanded with useful data and helpers for DataCore and hopefully generated once
+		//	so other components don't have to keep calculating the same data
+		let preparedProfileData = JSON.parse(JSON.stringify(strippedPlayerData));
+		prepareProfileData(allcrew, preparedProfileData, dtImported);
+
+		// Store strippedPlayerData in session, so user doesn't have to re-import after leaving playertools page
+		//	Must also store voyage and event data for voyage calculator
+		asyncSessionStorage.setItem('playerData', JSON.stringify(strippedPlayerData));
+		asyncSessionStorage.setItem('voyageData', JSON.stringify(voyageData));
+		asyncSessionStorage.setItem('eventData', JSON.stringify(eventData));
+
+		// After this point, playerData should always be preparedProfileData, here and in all components
+		this.setState({ playerData: preparedProfileData, strippedPlayerData, voyageData, eventData });
+	}
+
+	async _prepareProfileDataFromSession() {
+		const { strippedPlayerData } = this.state;
+
+		const [crewResponse] = await Promise.all([
+			fetch('/structured/crew.json'),
+		]);
+
+		const allcrew = await crewResponse.json();
+
+		let preparedProfileData = JSON.parse(JSON.stringify(strippedPlayerData));
+		prepareProfileData(allcrew, preparedProfileData, new Date(Date.parse(strippedPlayerData.calc.lastImported)));
+
+		this.setState({ playerData: preparedProfileData });
+	}
+
+	render() {
+		const { playerData, inputPlayerData, strippedPlayerData } = this.state;
+
+		if (!playerData && (inputPlayerData || strippedPlayerData)) {
+			return (
+				<Layout title='Player tools'>
+					<Container style={{ paddingTop: '4em', paddingBottom: '2em' }}>
+						<Icon loading name='spinner' /> Loading...
+					</Container>
+				</Layout>
+			);
+		}
+
+		if (!playerData)
+			return this.renderInputForm();
+
+		const panes = [
+			{
+				menuItem: 'Voyage Calculator',
+				render: () => <VoyageCalculator playerData={playerData} voyageData={this.state.voyageData} eventData={this.state.eventData} />
+			},
+			{
+				menuItem: 'Crew',
+				render: () => <ProfileCrew playerData={playerData} isTools={true} />
+			},
+			{
+				menuItem: 'Crew (mobile)',
+				render: () => <ProfileCrewMobile playerData={playerData} isMobile={false} />
+			},
+			{
+				menuItem: 'Crew Retrieval',
+				render: () => <CrewRetrieval playerData={playerData} />
+			},
+			{
+				menuItem: 'Ships',
+				render: () => <ProfileShips playerData={playerData} />
+			},
+			{
+				menuItem: 'Items',
+				render: () => <ProfileItems playerData={playerData} />
+			},
+			{
+				menuItem: 'Unneeded Items',
+				render: () => <UnneededItems playerData={playerData} />
+			},
+			{
+				menuItem: 'Other',
+				render: () => <ProfileOther playerData={playerData} />
+			},
+			{
+				menuItem: 'Charts & Stats',
+				render: () => <ProfileCharts playerData={playerData} />
+			}
+		];
+
+		return (
+			<Layout title='Player tools'>
+				<Container style={{ paddingTop: '4em', paddingBottom: '2em' }}>
+					<Header as='h4'>Hello, {playerData.player.character.display_name}</Header>
+					<Message icon>
+						<Icon name='bell' />
+						<Message.Content>
+							<Message.Header>Share your player profile!</Message.Header>
+							{!this.state.profileUploaded && (
+								<p>
+									Click here to{' '}
+									<Button size='small' color='green' onClick={() => this._shareProfile()}>
+										{this.state.uploading && <Icon loading name='spinner' />}share your profile
+									</Button>{' '}
+									and unlock more tools and export options for items and ships. More details:
+								</p>
+							)}
+							{!this.state.profileUploaded && (
+								<Message.List>
+									<Message.Item>
+										Once shared, the profile will be publicly accessible by anyone that has the link (or knows your DBID)
+									</Message.Item>
+									<Message.Item>
+										There is no private information included in the player profile; information being shared is limited to:{' '}
+										<b>captain name, level, vip level, fleet name and role, achievements, completed missions, your crew, items and ships.</b>
+									</Message.Item>
+								</Message.List>
+							)}
+							{this.state.profileUploaded && (
+								<p>
+									Your profile was uploaded. Share the link:{' '}
+									<a
+										href={`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}
+										target='_blank'>{`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}</a>
+								</p>
+							)}
+						</Message.Content>
+					</Message>
+
+					<Menu compact>
+						{playerData.calc.lastModified && (
+							<Dropdown item text={`Player data imported: ${playerData.calc.lastModified.toLocaleString()}`}>
+								<Dropdown.Menu>
+									<Dropdown.Item onClick={() => this._forceInputForm()}>Update now...</Dropdown.Item>
+									<Dropdown.Item onClick={() => this._clearPlayerData()}>Clear player data</Dropdown.Item>
+								</Dropdown.Menu>
+							</Dropdown>
+						)}
+						<Button onClick={() => this._exportCrew()} content='Export crew spreadsheet...' />
+					</Menu>
+
+					<Tab menu={{ secondary: true, pointing: true }} panes={panes} style={{ marginTop: '1em' }} />
+				</Container>
+			</Layout>
+		);
+	}
+
+	_clearPlayerData() {
+		asyncSessionStorage.clear();
+		this._forceInputForm();
+	}
+
+	_forceInputForm() {
+		this.setState({
+			playerData: undefined,
+			inputPlayerData: undefined,
+			strippedPlayerData: undefined,
+			fullInput: '',
+			displayedInput: ''
+		});
+	}
+
+	_shareProfile() {
+		this.setState({ profileUploading: true });
+		const { playerData, strippedPlayerData } = this.state;
+
+		let jsonBody = JSON.stringify({
+			dbid: playerData.player.dbid,
+			player_data: strippedPlayerData
+		});
+
+		fetch(`${process.env.GATSBY_DATACORE_URL}api/post_profile`, {
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: jsonBody
+		}).then(() => {
+			window.open(`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`, '_blank');
+			this.setState({ profileUploading: false, profileUploaded: true });
+		});
+	}
+
+	_exportCrew() {
+		const { playerData } = this.state;
+
+		let text = exportCrew(playerData.player.character.crew.concat(playerData.player.character.unOwnedCrew));
+		downloadData(`data:text/csv;charset=utf-8,${encodeURIComponent(text)}`, 'crew.csv');
+	}
+
+	renderInputForm() {
+		const { errorMessage } = this.state;
+
+		return (
+				<Layout>
+					<Container style={{ paddingTop: '4em', paddingBottom: '2em' }}>
+						<Header as='h4'>Player tools</Header>
+						<p>You can access some of your player data from the game's website and import it here to calculate optimal voyage lineups, identify unnecessary items, export your crew list as a CSV, or share your profile with other players, among other tools. This website cannot make direct requests to the game's servers due to security configurations and unclear terms of service interpretations, so there are a few manual steps required to import your data.</p>
+						<p>If you have multiple accounts, we recommend using your browser in InPrivate mode (Edge) or Incognito mode (Firefox / Chrome) to avoid caching your account credentials, making it easier to change accounts.</p>
+						<ul>
+							<li>
+								Open this page in your browser:{' '}
+								<a href={PLAYERLINK} target='_blank'>
+									https://stt.disruptorbeam.com/player
+								</a>
+							</li>
+							<li>
+								Log in if asked, then wait for the page to finish loading. It should start with:{' '}
+								<span style={{ fontFamily: 'monospace' }}>{'{"action":"update","player":'}</span> ...
+							</li>
+							<li>Select everything in the page (Ctrl+A) and copy it (Ctrl+C)</li>
+							<li>Paste it (Ctrl+V) in the text box below. Note that only the first few lines may be displayed</li>
+							<li>Click the 'Import data' button</li>
+						</ul>
+
+						<Form>
+							<TextArea
+								placeholder='Paste your player data here'
+								value={this.state.displayedInput}
+								onChange={(e, { value }) => this.setState({ displayedInput: value })}
+								onPaste={(e) => { return this._onPaste(e) }}
+							/>
+							<input
+								type='file'
+								onChange={(e) => { this._handleFileUpload(e) }}
+								style={{display:'none'}}
+								ref={e => this.inputUploadFile = e}
+							/>
+						</Form>
+
+						<Button
+							onClick={() => this._parseInput()}
+							style={{ marginTop: '1em' }}
+							content='Import data'
+							icon='paste'
+							labelPosition='right'
+						/>
+
+						{errorMessage && (
+							<Message negative>
+								<Message.Header>Error</Message.Header>
+								<p>{errorMessage}</p>
+							</Message>
+						)}
+					</Container>
+
+					<Container style={{ paddingBottom: '2em' }}>
+						<p>To circumvent the long text copy limitations on mobile devices, download{' '}
+							<a href={PLAYERLINK} target='_blank'>
+								your player data
+							</a>
+							{' '}to your device, then click the 'Upload data file' button.
+						</p>
+						<p>
+							<Modal
+								trigger={<a href="#">Click here for detailed instructions for Apple iOS devices.</a>}
+								header='Player data upload on iOS'
+								content={<ul>
+									<li>Go to your player data using the link provided, logging in if asked.</li>
+									<li>Wait for the page to finish loading. It should start with:{' '}
+											<span style={{ fontFamily: 'monospace' }}>{'{"action":"update","player":'}</span> ...
+									</li>
+									<li>Press the share icon while viewing the page.</li>
+									<li>Tap 'options' and choose 'Web Archive', tap 'save to files', choose a location and save.</li>
+									<li>Come back to this page (DataCore.app player tools).</li>
+									<li>Tap the 'Upload data file' button.</li>
+									<li>Choose the file starting with 'player?client_api...' from where you saved it.</li>
+								</ul>}
+							/>
+						</p>
+
+						<Button
+							onClick={() => this.inputUploadFile.click()}
+							content='Upload data file'
+							icon='file'
+							labelPosition='right'
+						/>
+					</Container>
+				</Layout>
+		);
+	}
+
+	_onPaste(event) {
+		let paste = event.clipboardData || window.clipboardData;
+		if (paste) {
+			let fullInput = paste.getData('text');
+			let displayedInput = fullInput.substr(0, 500)+' [ ... ]';
+			this.setState({ fullInput, displayedInput });
+			event.preventDefault();
+			return false;
+		}
+		return true;
+	}
+
+	_handleFileUpload(event) {
+		// use FileReader to read file content in browser
+		const fReader = new FileReader();
+		fReader.onload = (e) => {
+			let data = e.target.result.toString();
+			// Handle Apple webarchive wrapping
+			if (data.match(/^bplist00/)) {
+				// Find where the JSON begins and ends, and extract just that from the larger string.
+				data = data.substring(data.indexOf('{'), data.lastIndexOf('}}')+2);
+			}
+			this.setState({ fullInput: data });
+			this._parseInput();
+		};
+		fReader.readAsText(event.target.files[0]);
+	}
+
+	_parseInput() {
+		// Use inputted text if no pasted text detected
+		if (this.state.fullInput == '')
+			this.setState({ fullInput: this.state.displayedInput });
+
+		try {
+			let playerData = JSON.parse(this.state.fullInput as string);
+
+			if (playerData && playerData.player && playerData.player.display_name) {
+				if (playerData.player.character && playerData.player.character.crew && (playerData.player.character.crew.length > 0)) {
+					this.setState({ inputPlayerData: playerData, errorMessage: undefined });
+				} else {
+					this.setState({ errorMessage: 'Failed to parse player data from the text you pasted. Make sure you are logged in with the correct account.' });
+				}
+			} else {
+				this.setState({
+					errorMessage:
+						'Failed to parse player data from the text you pasted. Make sure the page is loaded correctly and you copied the entire contents!'
+				});
+			}
+		} catch (err) {
+			this.setState({
+				errorMessage: `Failed to read the data. Make sure the page is loaded correctly and you copied the entire contents! (${err})`
+			});
+		}
+	}
+}
+
+export default PlayerToolsPage;


### PR DESCRIPTION
This is #74, but split up into 2 parts, all based on a more recent master. This first half isolates new files from changed files. Until the second half is merged, the refactored player tools can only be accessed directly at `/playertools`

Integrated new changes since the latest commit to #74:
#104 Added Player tools title to layout property for SEO
#116 Added new dialog with abort button to voyage calculator component

Topline changes from #74:
Created a new player tools landing page (`playertools.tsx`). It's functionally similar to the previous one, but reworks a lot of the internals to match the structure of the existing profile page and to make it easier to maintain going forward. All components have been moved inside the landing page, with a new component created for the unneeded items tool (`unneededitems.tsx`) and a new component that's exclusively dedicated to the voyage calculator (`voyagecalculator_iap.tsx`).

All player tools now work with the same customized `playerData` variation (generated by `prepareProfileData`). Future components should use that instead of any other versions of player data whenever possible.

A stripped version of player data (the same format that is used when sharing profiles) is now saved in session storage, so that a user will not have to re-import the `player.json` file if they click away from the player tools. A timestamp of the import is now shown on the landing page and acts as a button to allow users to update or clear their player data. This player data only resides in session until the user closes the browser.

This adds a new tier to Unneeded Items so that unneeded items are presented as 1) unneeded schematics, 2) unneeded crew-specific items, and 3) unneeded generic items that could be useful later. It also makes the tool a little more conservative when considering items.

Fixes #15, #21, #46, #73