### PR TITLE
Add progress info to collections

### DIFF
--- a/src/components/crewretrieval.tsx
+++ b/src/components/crewretrieval.tsx
@@ -131,11 +131,15 @@ class CrewRetrieval extends Component<CrewRetrievalProps, CrewRetrievalState> {
 		
 		let cArr = [...new Set(data.map(a => a.collections).flat())].sort();
 		cArr.forEach(c => {
+			let pc = this.props.playerData.player.character.cryo_collections.find((pc) => pc.name === c);
 			let kv = cArr.indexOf(c) + 1;
 			collectionsOptions.push({
 				key: kv,
-				value: kv,
-				text: c
+				value: c,
+				text: c,
+				content: (
+					<span>{c} <span style={{ whiteSpace: 'nowrap' }}>({pc.progress} / {pc.milestone.goal || 'max'})</span></span>
+				),
 			});
 		});
 	}
@@ -323,8 +327,7 @@ class CrewRetrieval extends Component<CrewRetrievalProps, CrewRetrievalState> {
 		}
 		
 		if (collection) {
-			let cName = collectionsOptions.find(o => o.key === collection).text;
-			data = data.filter((crew) => crew.collections.indexOf(cName) !== -1);
+			data = data.filter((crew) => crew.collections.indexOf(collection) !== -1);
 		}
 		
 		let totalPages = Math.ceil(data.length / this.state.pagination_rows);

--- a/src/utils/playerutils.ts
+++ b/src/utils/playerutils.ts
@@ -25,7 +25,6 @@ export function stripPlayerData(items: any[], p: any): any {
 	delete p.player.character.cadet_tickets;
 	delete p.player.character.reroll_descriptions;
 	delete p.player.character.daily_rewards_state;
-	delete p.player.character.cryo_collections;
 	delete p.player.character.location;
 	delete p.player.character.destination;
 	delete p.player.character.video_ad_chroniton_boost_reward;


### PR DESCRIPTION
The collections information was previously stripped from playerData. Using this data, the PR adds progress information to the collections dropdown field on the crew retrieval page.

![image](https://user-images.githubusercontent.com/65423314/110243003-cee69680-7f58-11eb-9b73-21e26e16c1cf.png)

The data is always shown in the format of (current progress / next milestone) where the next milestone target is replaced with 'max' if a collection has no more outstanding milestones.