### PR TITLE
Add sanity check for collection progress

### DIFF
--- a/src/components/crewretrieval.tsx
+++ b/src/components/crewretrieval.tsx
@@ -131,7 +131,7 @@ class CrewRetrieval extends Component<CrewRetrievalProps, CrewRetrievalState> {
 		
 		let cArr = [...new Set(data.map(a => a.collections).flat())].sort();
 		cArr.forEach(c => {
-			let pc = this.props.playerData.player.character.cryo_collections.find((pc) => pc.name === c);
+			let pc = this.props.playerData.player.character.cryo_collections ? this.props.playerData.player.character.cryo_collections.find((pc) => pc.name === c) : { progress: 'n/a', milestone: { goal: 'n/a' }};
 			let kv = cArr.indexOf(c) + 1;
 			collectionsOptions.push({
 				key: kv,


### PR DESCRIPTION
If a user still has old cached `playerData` in their browser storage from before 7ee0c2c94bde377e716a4e10927dbdd421f30ceb went live, they'll get a white page upon accessing `crewretrieval.tsx`