### PR TITLE
Terminates web worker properly when user aborted

### DIFF
--- a/src/components/voyagecalculator_iap.tsx
+++ b/src/components/voyagecalculator_iap.tsx
@@ -4,6 +4,7 @@ import ItemDisplay from '../components/itemdisplay';
 import {
 	ICalcResult,
 	calculateVoyage,
+	abortVoyageCalculation,
 	formatTimeSeconds,
 	BonusCrew
 } from '../utils/voyageutils';
@@ -271,7 +272,7 @@ class VoyageCalculator extends Component<VoyageCalculatorProps, VoyageCalculator
                     </Modal.Content>
                     <Modal.Description>
                         <Segment basic textAlign={"center"}>
-                            <Button onClick={e => this.setState({calcState : CalculatorState.Done})}>Abort</Button>
+                            <Button onClick={e => { abortVoyageCalculation(), this.setState({calcState : CalculatorState.Done})}}>Abort</Button>
                         </Segment>
                     </Modal.Description>
                 </Modal>

--- a/src/utils/voyageutils.ts
+++ b/src/utils/voyageutils.ts
@@ -244,11 +244,12 @@ export function exportVoyageData(options) {
 	return dataToExport;
 }
 
+var iap_worker = null;
 export function calculateVoyage(options, progressCallback: (result: ICalcResult) => void, doneCallback: (result: ICalcResult) => void) {
 	let dataToExport = exportVoyageData(options);
 
-	const worker = new ComputeWorker();
-	worker.addEventListener('message', message => {
+	iap_worker = new ComputeWorker();
+	iap_worker.addEventListener('message', message => {
 		if (message.data.progressResult) {
 			progressCallback(parseResults(Uint8Array.from(message.data.progressResult)));
 		} else if (message.data.result) {
@@ -256,7 +257,11 @@ export function calculateVoyage(options, progressCallback: (result: ICalcResult)
 		}
 	});
 
-	worker.postMessage(dataToExport);
+	iap_worker.postMessage(dataToExport);
+}
+
+export function abortVoyageCalculation() {
+	if(iap_worker) iap_worker.terminate();
 }
 
 export class BonusCrew {


### PR DESCRIPTION
When the user clicks the abort button during a voyage calculation, the web worker running the iap wasm code will now be properly terminated.

> One last note, re: my modifying of the current worker code. I don't think the abort button as implemented is actually cancelling the web worker, so much as it's hiding the spinner while the process continues in the background. You can see this for yourself if you abort really early into a calculation. The spinner just pops up again if the worker has more results. My hacky fix was to keep the worker in state and then terminate it when the abort button is clicked. If someone with a better understanding of web workers can verify the issue and push a real fix to the site, that would be great.

_Originally posted by @ussjohnjay in https://github.com/stt-datacore/website/issues/125#issuecomment-793843154_