### PR TITLE
Adds rarity filtering to behold helper

### DIFF
--- a/src/components/commoncrewdata.tsx
+++ b/src/components/commoncrewdata.tsx
@@ -97,8 +97,8 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 								content: {
 									content: (
 										<Segment.Group raised>
-											{crew.skill_data.map((sk: any) => (
-												<Segment>
+											{crew.skill_data.map((sk: any, idx: number) => (
+												<Segment key={idx}>
 													<Rating
 														defaultRating={sk.rarity}
 														maxRating={crew.max_rarity}


### PR DESCRIPTION
In anticipation of this week's honor sale, this adds rarity filtering to the behold helper to narrow down (thus speeding up) the crew selection dropdown. The default minimum rarity here is set to 4, which should be more preferable to those using this tool for beholds. The default can be changed to match the previous behavior (no minimum) or perhaps temporarily set to 5, at least for the honor sale.

This matches the appearance of the rarity dropdown as currently rendered by the crew retrieval component, not the changes proposed in #140. If that gets merged, this should be changed to match.

This also sorts the crew selection dropdown options alphabetically (first by short_name then crew name). Additionally when an option is selected, the dropdown now closes.

Lastly, this adds an index where expected for a mapping in commoncrewdata.