### PR TITLE
Adds search box to profile crew page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,17 +7,14 @@ import { SearchableTable, ITableConfigRow } from '../components/searchabletable'
 
 import CONFIG from '../components/CONFIG';
 
+import { crewMatchesSearchFilter } from '../utils/crewsearch';
+
 type IndexPageProps = {};
 
 type IndexPageState = {
 	botcrew: any[];
+	searchFilterType: string;
 };
-
-const searchTypeOptions = [
-    { key : '0', value : 'Exact', text : 'Exact match only' },
-    { key : '1', value : 'Whole word', text : 'Whole word only' },
-    { key : '2', value : 'Any match', text : 'Match any text' }
-];
 
 const tableConfig: ITableConfigRow[] = [
 	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
@@ -31,13 +28,8 @@ const tableConfig: ITableConfigRow[] = [
 ];
 
 class IndexPage extends Component<IndexPageProps, IndexPageState> {
-	state = { botcrew: [], searchType : 'Any match' };
-    searchTypes = {
-        'Exact': (input: string, searchString: string) => input.toLowerCase() == searchString.toLowerCase(),
-        'Whole word': (input: string, searchString: string) => new RegExp('\\b' + searchString + '\\b', 'i').test(input),
-        'Any match': (input: string, searchString: string) => input.toLowerCase().indexOf(searchString.toLowerCase()) >= 0
-    };
-    
+	state = { botcrew: [], searchFilterType: 'Any match' };
+
 	async componentDidMount() {
 		let response = await fetch('/structured/crew.json');
 		const botcrew = await response.json();
@@ -50,72 +42,6 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 		});
 
 		this.setState({ botcrew });
-	}
-
-	_filterCrew(crew: any, filters: []): boolean {
-		const matchesFilter = this.searchTypes[this.state.searchType];
-		let meetsAnyCondition = false;
-
-		for (let filter of filters) {
-			let meetsAllConditions = true;
-			if (filter.conditionArray.length === 0) {
-				// text search only
-				for (let segment of filter.textSegments) {
-					let segmentResult =
-						matchesFilter(crew.name, segment.text) ||
-						matchesFilter(crew.short_name, segment.text) ||
-						crew.nicknames.some(n => matchesFilter(n.cleverThing, segment.text)) ||
-						crew.traits_named.some(t => matchesFilter(t, segment.text)) ||
-						crew.traits_hidden.some(t => matchesFilter(t, segment.text));
-					meetsAllConditions = meetsAllConditions && (segment.negated ? !segmentResult : segmentResult);
-				}
-			} else {
-				let rarities = [];
-				for (let condition of filter.conditionArray) {
-					let conditionResult = true;
-					if (condition.keyword === 'name') {
-						conditionResult = matchesFilter(crew.name, condition.value);
-					} else if (condition.keyword === 'trait') {
-						conditionResult =
-							crew.traits_named.some(t => matchesFilter(t, condition.value)) ||
-							crew.traits_hidden.some(t => matchesFilter(t, condition.value));
-					} else if (condition.keyword === 'rarity') {
-						if (!condition.negated) {
-							rarities.push(Number.parseInt(condition.value));
-							continue;
-						}
-
-						conditionResult = crew.max_rarity === Number.parseInt(condition.value);
-					} else if (condition.keyword === 'skill') {
-						// Only full skill names or short names are valid here e.g. command or cmd
-						let skillShort = CONFIG.SKILLS_SHORT.find(skill => skill.short === condition.value.toUpperCase());
-						let skillName = skillShort ? skillShort.name : condition.value.toLowerCase()+"_skill";
-						conditionResult = skillName in crew.base_skills;
-					} else if (condition.keyword === 'in_portal') {
-						conditionResult = condition.value.toLowerCase() === 'true' ? crew.in_portal : !crew.in_portal;
-					}
-					meetsAllConditions = meetsAllConditions && (condition.negated ? !conditionResult : conditionResult);
-				}
-
-				if (rarities.length > 0) {
-					meetsAllConditions = meetsAllConditions && rarities.includes(crew.max_rarity);
-				}
-
-				for (let segment of filter.textSegments) {
-					let segmentResult =
-						matchesFilter(crew.name, segment.text) ||
-						crew.traits_named.some(t => matchesFilter(t, segment.text)) ||
-						crew.traits_hidden.some(t => matchesFilter(t, segment.text));
-					meetsAllConditions = meetsAllConditions && (segment.negated ? !segmentResult : segmentResult);
-				}
-			}
-			if (meetsAllConditions) {
-				meetsAnyCondition = true;
-				break;
-			}
-		}
-
-		return meetsAnyCondition;
 	}
 
 	renderTableRow(crew: any): JSX.Element {
@@ -173,54 +99,12 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 				<Header as='h2'>Crew stats</Header>
 
 				<SearchableTable
+					id="index"
 					data={botcrew}
-					explanation={
-						<div>
-							<p>
-								Search for crew by name or trait (with optional '-' for exclusion). For example, this returns all Rikers
-								that are not romantic:
-							</p>
-							<p>
-								<code>riker -romantic</code>
-							</p>
-
-							<p>
-								Search for multiple crew by separating terms with <b>OR</b>. This returns any Tuvok or T'Pol:
-							</p>
-							<p>
-								<code>tuvok OR tpol</code>
-							</p>
-
-							<p>
-								Specify <b>name</b>, <b>trait</b>, <b>rarity</b> or <b>skill</b> fields for more advanced searches. This
-								returns all female crew of rarity 4 or 5 with science skill and the Q Continuum trait:
-							</p>
-							<p>
-								<code>trait:female rarity:4,5 skill:sci trait:"q continuum"</code>
-							</p>
-
-							<p>
-								Search for all crew that are in the game portal (<b>true</b>) or not (any other value):
-							</p>
-							<p>
-								<code>in_portal:true</code>
-							</p>
-						</div>
-					}
-					renderTableRow={crew => this.renderTableRow(crew)}
-					filterRow={(crew, filter) => this._filterCrew(crew, filter)}
 					config={tableConfig}
-					searchExt = { 
-						<span style={{ paddingLeft: '2em' }}>
-							<Dropdown inline
-										options={searchTypeOptions}
-										value={this.state.searchType}
-										onChange={(event, {value}) => 
-										this.setState({ searchType: value as number })
-										}
-							/>
-						</span>
-					}
+					renderTableRow={crew => this.renderTableRow(crew)}
+					filterRow={(crew, filter, filterType) => crewMatchesSearchFilter(crew, filter, filterType)}
+					showFilterOptions="true"
 				/>
 
 				<p>

--- a/src/pages/items.tsx
+++ b/src/pages/items.tsx
@@ -80,6 +80,8 @@ class ItemsPage extends Component<ItemsPageProps, ItemsPageState> {
 	}
 
 	_filterItem(item: any, filters: []): boolean {
+		if (filters.length == 0) return true;
+
 		const matchesFilter = (input: string, searchString: string) =>
 			input.toLowerCase().indexOf(searchString.toLowerCase()) >= 0;
 
@@ -152,6 +154,7 @@ class ItemsPage extends Component<ItemsPageProps, ItemsPageState> {
 				)}
 				{this.state.items && (
 					<SearchableTable
+						id="items"
 						data={this.state.items}
 						explanation={
 							<div>

--- a/src/utils/crewsearch.ts
+++ b/src/utils/crewsearch.ts
@@ -1,0 +1,74 @@
+import CONFIG from '../components/CONFIG';
+
+export function crewMatchesSearchFilter(crew: any, filters: [], filterType: string): boolean {
+	if (filters.length == 0) return true;
+
+    const filterTypes = {
+        'Exact': (input: string, searchString: string) => input.toLowerCase() == searchString.toLowerCase(),
+        'Whole word': (input: string, searchString: string) => new RegExp('\\b' + searchString + '\\b', 'i').test(input),
+        'Any match': (input: string, searchString: string) => input.toLowerCase().indexOf(searchString.toLowerCase()) >= 0
+    };
+	const matchesFilter = filterTypes[filterType];
+	let meetsAnyCondition = false;
+
+	for (let filter of filters) {
+		let meetsAllConditions = true;
+		if (filter.conditionArray.length === 0) {
+			// text search only
+			for (let segment of filter.textSegments) {
+				let segmentResult =
+					matchesFilter(crew.name, segment.text) ||
+					matchesFilter(crew.short_name, segment.text) ||
+					crew.nicknames.some(n => matchesFilter(n.cleverThing, segment.text)) ||
+					crew.traits_named.some(t => matchesFilter(t, segment.text)) ||
+					crew.traits_hidden.some(t => matchesFilter(t, segment.text));
+				meetsAllConditions = meetsAllConditions && (segment.negated ? !segmentResult : segmentResult);
+			}
+		} else {
+			let rarities = [];
+			for (let condition of filter.conditionArray) {
+				let conditionResult = true;
+				if (condition.keyword === 'name') {
+					conditionResult = matchesFilter(crew.name, condition.value);
+				} else if (condition.keyword === 'trait') {
+					conditionResult =
+						crew.traits_named.some(t => matchesFilter(t, condition.value)) ||
+						crew.traits_hidden.some(t => matchesFilter(t, condition.value));
+				} else if (condition.keyword === 'rarity') {
+					if (!condition.negated) {
+						rarities.push(Number.parseInt(condition.value));
+						continue;
+					}
+
+					conditionResult = crew.max_rarity === Number.parseInt(condition.value);
+				} else if (condition.keyword === 'skill') {
+					// Only full skill names or short names are valid here e.g. command or cmd
+					let skillShort = CONFIG.SKILLS_SHORT.find(skill => skill.short === condition.value.toUpperCase());
+					let skillName = skillShort ? skillShort.name : condition.value.toLowerCase()+"_skill";
+					conditionResult = skillName in crew.base_skills;
+				} else if (condition.keyword === 'in_portal') {
+					conditionResult = condition.value.toLowerCase() === 'true' ? crew.in_portal : !crew.in_portal;
+				}
+				meetsAllConditions = meetsAllConditions && (condition.negated ? !conditionResult : conditionResult);
+			}
+
+			if (rarities.length > 0) {
+				meetsAllConditions = meetsAllConditions && rarities.includes(crew.max_rarity);
+			}
+
+			for (let segment of filter.textSegments) {
+				let segmentResult =
+					matchesFilter(crew.name, segment.text) ||
+					crew.traits_named.some(t => matchesFilter(t, segment.text)) ||
+					crew.traits_hidden.some(t => matchesFilter(t, segment.text));
+				meetsAllConditions = meetsAllConditions && (segment.negated ? !segmentResult : segmentResult);
+			}
+		}
+		if (meetsAllConditions) {
+			meetsAnyCondition = true;
+			break;
+		}
+	}
+
+	return meetsAnyCondition;
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,47 @@
+import React from 'react';
+import * as localForage from 'localforage';
+
+interface StorageOptions {
+	rememberForever?: boolean;	// We store in session unless told to remember forever
+	useDefault?: boolean;	// Use default value as initial value instead of any stored value
+	useAndStoreDefault?: boolean;	// Use default and store it immediately to avoid render loops
+}
+
+const StorageDefaultOptions: StorageOptions = {
+	rememberForever: false,
+	useDefault: false,
+	useAndStoreDefault: false
+}
+
+export const useStateWithStorage = (itemKey: string, itemDefault: any, options?: StorageOptions) => {
+	if (!options) options = StorageDefaultOptions;
+
+	// Set initial value (either from storage or default value) in state
+	const [value, setValue] = React.useState(() => {
+			if (options.useAndStoreDefault) {
+				storeItem(itemKey, itemDefault, options.rememberForever);
+				return itemDefault;
+			}
+			if (options.useDefault) return itemDefault;
+			return getItem(itemKey, itemDefault, options.rememberForever);
+		}
+	);
+
+	// Update stored value when value changed in state
+	React.useEffect(() => { storeItem(itemKey, value, options.rememberForever); }, [value]);
+
+	return [value, setValue];
+};
+
+// Use JSON.stringify and JSON.parse to preserve item types when storing, getting
+const storeItem = (itemKey: string, itemValue: any, rememberForever: boolean) => {
+	if (rememberForever)
+		localForage.setItem(itemKey, JSON.stringify(itemValue));
+	else
+		sessionStorage.setItem(itemKey, JSON.stringify(itemValue));
+};
+const getItem = (itemKey: string, itemDefault: any, rememberForever: boolean) => {
+	let storedValue = rememberForever ? localForage.getItem(itemKey) : sessionStorage.getItem(itemKey);
+	if (!storedValue) return itemDefault;
+	return JSON.parse(storedValue);
+};


### PR DESCRIPTION
This adds a search box to the crew roster component on player tools and profiles, but there's a lot going on under the hood in this one:

This refactors searchabletable and profile_crew to use React hooks. Among other benefits, this will allow us to more easily tie state data to session, thus letting us store form data on any page that needs it. You can see it in action right now with the refactored profile crew page.

A new storage utils file holds the logic for the storage hook. It uses sessionStorage by default, but it should work with localStorage too. Hopefully this will be fully compatible with other components, but some may need to be refactored first.

Moved some logic to searchabletable and the new crewsearch utils file, so that searchabletable can handle sorting and filtering by search string for more components (in this case, profile_crew but hopefully crew retrieval down the line). The main index and items page were updated to be compatible with these changes.

The profile crew component now has a checkbox to toggle frozen crew.

But really this is all just to see if I can create a new Cloudflare test page from a PR.