### PR TITLE
Remember last active player tool

### DIFF
--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -13,12 +13,12 @@ import { useStateWithStorage } from '../utils/storage';
 const tableConfig: ITableConfigRow[] = [
 	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
 	{ width: 1, column: 'max_rarity', title: 'Rarity' },
-	{ width: 1, column: 'command_skill', title: 'Command' },
-	{ width: 1, column: 'science_skill', title: 'Science' },
-	{ width: 1, column: 'security_skill', title: 'Security' },
-	{ width: 1, column: 'engineering_skill', title: 'Engineering' },
-	{ width: 1, column: 'diplomacy_skill', title: 'Diplomacy' },
-	{ width: 1, column: 'medicine_skill', title: 'Medicine' }
+	{ width: 1, column: 'command_skill.core', title: 'Command' },
+	{ width: 1, column: 'science_skill.core', title: 'Science' },
+	{ width: 1, column: 'security_skill.core', title: 'Security' },
+	{ width: 1, column: 'engineering_skill.core', title: 'Engineering' },
+	{ width: 1, column: 'diplomacy_skill.core', title: 'Diplomacy' },
+	{ width: 1, column: 'medicine_skill.core', title: 'Medicine' }
 ];
 
 type ProfileCrewProps = {
@@ -32,18 +32,7 @@ const ProfileCrew = (props: ProfileCrewProps) => {
 	const [showFrozen, setShowFrozen] = useStateWithStorage('showFrozen', true);
 	const [findDupes, setFindDupes] = useStateWithStorage('findDupes', false);
 
-	const data = initCrewData();
-
-	function initCrewData(): [] {
-		let crew = [...props.playerData.player.character.crew];
-		// Add dummy fields for sorting to work
-		crew.forEach(crew => {
-			CONFIG.SKILLS_SHORT.forEach(skill => {
-				crew[skill.name] = crew.base_skills[skill.name] ? crew.base_skills[skill.name].core : 0;
-			});
-		});
-		return crew;
-	}
+	const data = [...props.playerData.player.character.crew];
 
 	function showThisCrew(crew: any, filters: [], filterType: string): boolean {
 		if (!showFrozen && crew.immortal > 0) {

--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -29,8 +29,9 @@ type ProfileCrewProps = {
 const ProfileCrew = (props: ProfileCrewProps) => {
 	const { isTools } = props;
 
-	const [showFrozen, setShowFrozen] = useStateWithStorage('showFrozen', true);
-	const [findDupes, setFindDupes] = useStateWithStorage('findDupes', false);
+	const pageId = isTools ? 'tools' : 'profile';
+	const [showFrozen, setShowFrozen] = useStateWithStorage(pageId+'/crew/showFrozen', true);
+	const [findDupes, setFindDupes] = useStateWithStorage(pageId+'/crew/findDupes', false);
 
 	const data = [...props.playerData.player.character.crew];
 

--- a/src/components/profile_crew2.tsx
+++ b/src/components/profile_crew2.tsx
@@ -36,6 +36,7 @@ type ProfileCrewMobileState = {
 	excludeFF: boolean;
 	onlyEvent: boolean;
 	sortKind: SkillSort;
+	itemsReady: boolean;
 };
 
 class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMobileState> {
@@ -52,11 +53,13 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 			includeFrozen: false,
 			excludeFF: false,
 			onlyEvent: false,
-			sortKind: SkillSort.Base
+			sortKind: SkillSort.Base,
+			itemsReady: false
 		};
 	}
 
 	componentDidMount() {
+		let self = this;
 		fetch('/structured/items.json')
 			.then(response => response.json())
 			.then(items => {
@@ -68,10 +71,14 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 						}
 					});
 				});
+				this.setState({ itemsReady: true });
 			});
 
 		const data = this.state.data;
 		data.forEach((crew) => {
+			if (crew.symbol == 'martia_crew') {
+				console.log(crew);
+			}
 			Object.keys(crew).forEach((p) => {
 				if(p.substr(-6) === '_skill') {
 					crew[p].proficiency = crew[p].max - crew[p].min;
@@ -118,7 +125,7 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 				direction: 'ascending'
 			};
 		}
-		
+
 		if(config.activeItem) {
 			newActiveItem = activeItem === config.activeItem ? defaultColumn : config.activeItem;
 			newColumn = newActiveItem;
@@ -132,7 +139,7 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 			newColumn = column === config.column ? defaultColumn : config.column;
 			sortConfig.field = newColumn + (newColumn.substr(-6) === '_skill' ? (newSortKind || sortKind) : '');
 		}
-		
+
 		const sorted: IResultSortDataBy = sortDataBy(data, sortConfig);
 		this.setState({
 			activeItem: newActiveItem || activeItem,
@@ -186,7 +193,7 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 
 	render() {
 		const { includeFrozen, excludeFF, onlyEvent, activeItem, searchFilter } = this.state;
-		let { data } = this.state;
+		let { data, itemsReady } = this.state;
 
 		const { isMobile } = this.props;
 
@@ -304,7 +311,7 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 						}}
 					>
 						{data.map((crew, idx) => (
-							<VaultCrew key={idx} crew={crew} size={zoomFactor} />
+							<VaultCrew key={idx} crew={crew} size={zoomFactor} itemsReady={itemsReady} />
 						))}
 					</div>
 				</Segment>

--- a/src/components/profile_crew2.tsx
+++ b/src/components/profile_crew2.tsx
@@ -76,9 +76,6 @@ class ProfileCrewMobile extends Component<ProfileCrewMobileProps, ProfileCrewMob
 
 		const data = this.state.data;
 		data.forEach((crew) => {
-			if (crew.symbol == 'martia_crew') {
-				console.log(crew);
-			}
 			Object.keys(crew).forEach((p) => {
 				if(p.substr(-6) === '_skill') {
 					crew[p].proficiency = crew[p].max - crew[p].min;

--- a/src/components/vaultcrew.tsx
+++ b/src/components/vaultcrew.tsx
@@ -11,6 +11,7 @@ type VaultCrewProps = {
 	size: number;
 	style?: React.CSSProperties;
 	crew: any;
+	itemsReady: boolean;
 };
 
 function formatCrewStats(crew: any): JSX.Element {
@@ -42,7 +43,7 @@ function formatCrewStats(crew: any): JSX.Element {
 
 class VaultCrew extends PureComponent<VaultCrewProps> {
 	render() {
-		const { crew } = this.props;
+		const { crew, itemsReady } = this.props;
 		const SZ = (scale: number) => (this.props.size * scale).toFixed(2);
 		let borderColor = new TinyColor(CONFIG.RARITIES[crew.max_rarity].color);
 
@@ -139,11 +140,14 @@ class VaultCrew extends PureComponent<VaultCrewProps> {
 			display: 'flex'
 		};
 
-		let startlevel = crew.level === 100 ? 36 : Math.ceil(crew.level / 10) * 4;
+		// Dec levels can be either end of one equip range or start of the next (e.g. lvl 20 is 10-20 or 20-30)
+		//	Assume at the start of next range unless has multiple equips
+		let startlevel = Math.floor(crew.level / 10) * 4;
+		if (crew.level % 10 == 0 && crew.equipment.length > 1) startlevel = startlevel - 4;
 		let eqimgs = [];
-		if (!crew.equipment_slots[startlevel]) {
-			console.error(`Missing equipment slots information for crew '${crew.name}'`);
-			console.log(crew);
+		if (!crew.equipment_slots[startlevel] || !itemsReady) {
+			//console.error(`Missing equipment slots information for crew '${crew.name}'`);
+			//console.log(crew);
 			eqimgs = [
 				'items_equipment_box02_icon.png',
 				'items_equipment_box02_icon.png',

--- a/src/pages/playertools.tsx
+++ b/src/pages/playertools.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Container, Header, Message, Tab, Icon, Dropdown, Menu, Button, Form, TextArea, Checkbox, Modal } from 'semantic-ui-react';
 
 import Layout from '../components/layout';
@@ -26,27 +26,26 @@ const PlayerToolsPage = () => {
 	const [allCrew, setAllCrew] = React.useState(undefined);
 	const [allItems, setAllItems] = React.useState(undefined);
 
-	const [strippedPlayerData, setStrippedPlayerData] = useStateWithStorage('toolsPlayerData', undefined);
-	const [voyageData, setVoyageData] = useStateWithStorage('toolsVoyageData', undefined);
-	const [eventData, setEventData] = useStateWithStorage('toolsEventData', undefined);
+	const [strippedPlayerData, setStrippedPlayerData] = useStateWithStorage('tools/playerData', undefined);
+	const [voyageData, setVoyageData] = useStateWithStorage('tools/voyageData', undefined);
+	const [eventData, setEventData] = useStateWithStorage('tools/eventData', undefined);
 
-	const [activeIndex, setActiveIndex] = useStateWithStorage('toolsActiveIndex', 0);
-	const [showIfStale, setShowIfStale] = useStateWithStorage('toolsShowStale', true);
-
-	const [showShare, setShowShare] = useStateWithStorage('toolsShowShare', true, { rememberForever: true });
-	const [profileAutoUpdate, setProfileAutoUpdate] = useStateWithStorage('toolsProfileAutoUpdate', false, { rememberForever: true });
-	const [profileUploaded, setProfileUploaded] = React.useState(false);
-	const [profileUploading, setProfileUploading] = React.useState(false);
-
+	const [dataSource, setDataSource] = React.useState(undefined);
 	const [showForm, setShowForm] = React.useState(false);
-
-	React.useEffect(() => {
-		if (profileAutoUpdate) shareProfile();
-	}, [strippedPlayerData]);
 
 	// Profile data ready, show player tool panes
 	if (playerData && !showForm) {
-		return renderTools();
+		return (<PlayerToolsPanes
+					playerData={playerData}
+					strippedPlayerData={strippedPlayerData}
+					voyageData={voyageData}
+					eventData={eventData}
+					dataSource={dataSource}
+					allCrew={allCrew}
+					allItems={allItems}
+					requestShowForm={setShowForm}
+					requestClearData={clearPlayerData}
+				/>);
 	}
 
 	// Preparing profile data, show spinner
@@ -68,146 +67,6 @@ const PlayerToolsPage = () => {
 
 	// No data available, show input form
 	return (<PlayerToolsForm setValidInput={setValidInput} />);
-
-	function renderTools() {
-		const handleTabChange = (e, { activeIndex }) => setActiveIndex(activeIndex);
-
-		const panes = [
-			{
-				menuItem: 'Voyage Calculator',
-				render: () => <VoyageCalculator playerData={playerData} voyageData={voyageData} eventData={eventData} />
-			},
-			{
-				menuItem: 'Crew',
-				render: () => <ProfileCrew playerData={playerData} isTools={true} />
-			},
-			{
-				menuItem: 'Crew (mobile)',
-				render: () => <ProfileCrewMobile playerData={playerData} isMobile={false} />
-			},
-			{
-				menuItem: 'Crew Retrieval',
-				render: () => <CrewRetrieval playerData={playerData} />
-			},
-			{
-				menuItem: 'Ships',
-				render: () => <ProfileShips playerData={playerData} />
-			},
-			{
-				menuItem: 'Items',
-				render: () => <ProfileItems playerData={playerData} />
-			},
-			{
-				menuItem: 'Unneeded Items',
-				render: () => <UnneededItems playerData={playerData} />
-			},
-			{
-				menuItem: 'Other',
-				render: () => <ProfileOther playerData={playerData} />
-			},
-			{
-				menuItem: 'Charts & Stats',
-				render: () => <ProfileCharts playerData={playerData} />
-			}
-		];
-
-		const StaleMessage = () => {
-			const STALETHRESHOLD = 3;	// in hours
-			if (showIfStale && new Date().getTime()-playerData.calc.lastModified.getTime() > STALETHRESHOLD*60*60*1000) {
-				return (
-					<Message
-						warning
-						icon='clock'
-						header='Update your player data'
-						content="It's been a few hours since you last updated your player data. We recommend that you update now to make sure our tools are providing you recent information about your crew."
-						onDismiss={() => setShowIfStale(false)}
-					/>
-				);
-			}
-			else {
-				return (<></>);
-			}
-		};
-
-		const ShareMessage = () => {
-			if (!showShare) return (<></>);
-			// The option to auto-share profile only appears immediately after clicking the share button
-			//	or if the user has previously set the checkbox option to true
-			const bShowAutoOption = profileUploaded || profileAutoUpdate;
-			return (
-				<Message icon onDismiss={() => setShowShare(false)}>
-					<Icon name='share alternate' />
-					<Message.Content>
-						<Message.Header>Share your player profile!</Message.Header>
-						{!profileUploaded && (
-							<p>
-								Click here to{' '}
-								<Button size='small' color='green' onClick={() => shareProfile()}>
-									{profileUploading && <Icon loading name='spinner' />}share your profile
-									</Button>{' '}
-									and unlock more tools and export options for items and ships. More details:
-							</p>
-						)}
-						{!profileUploaded && (
-							<Message.List>
-								<Message.Item>
-									Once shared, the profile will be publicly accessible by anyone that has the link (or knows your DBID)
-									</Message.Item>
-								<Message.Item>
-									There is no private information included in the player profile; information being shared is limited to:{' '}
-									<b>captain name, level, vip level, fleet name and role, achievements, completed missions, your crew, items and ships.</b>
-								</Message.Item>
-							</Message.List>
-						)}
-						{profileUploaded && (
-							<p>
-								Your profile was uploaded. Share the link:{' '}
-								<a
-									href={`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}
-									target='_blank'>{`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}</a>
-							</p>
-						)}
-						{bShowAutoOption && (
-							<Form.Field
-								control={Checkbox}
-								label='Automatically share profile after every import'
-								checked={profileAutoUpdate}
-								onChange={(e, { checked }) => setProfileAutoUpdate(checked)}
-								style={{ marginTop: '1em' }}
-							/>
-						)}
-					</Message.Content>
-				</Message>
-			);
-		};
-
-		return (
-			<Layout title='Player tools'>
-				<Header as='h4'>Hello, {playerData.player.character.display_name}</Header>
-
-				<StaleMessage />
-
-				<Menu compact stackable>
-					<Menu.Item>
-						Last imported: {playerData.calc.lastModified.toLocaleString()}
-					</Menu.Item>
-					<Dropdown item text='Profile options'>
-						<Dropdown.Menu>
-							<Dropdown.Item onClick={() => setShowForm(true)}>Update now...</Dropdown.Item>
-							{!showShare && (<Dropdown.Item onClick={() => setShowShare(true)}>Share profile...</Dropdown.Item>)}
-							<Dropdown.Item onClick={() => clearPlayerData()}>Clear player data</Dropdown.Item>
-						</Dropdown.Menu>
-					</Dropdown>
-					<Button onClick={() => exportCrewTool()} content='Export crew spreadsheet...' />
-				</Menu>
-
-				<ShareMessage />
-
-				<Tab menu={{ secondary: true, pointing: true }} panes={panes} style={{ marginTop: '1em' }}
-					activeIndex={activeIndex} onTabChange={handleTabChange} />
-			</Layout>
-		);
-	}
 
 	function renderSpinner() {
 		return (
@@ -278,14 +137,14 @@ const PlayerToolsPage = () => {
 		let preparedProfileData = {...strippedData};
 		prepareProfileData(allCrew, preparedProfileData, dtImported);
 		setPlayerData(preparedProfileData);
-
-		setShowIfStale(true);
+		setDataSource('input');
 	}
 
 	function prepareProfileDataFromSession() {
 		let preparedProfileData = {...strippedPlayerData};
 		prepareProfileData(allCrew, preparedProfileData, new Date(Date.parse(strippedPlayerData.calc.lastImported)));
 		setPlayerData(preparedProfileData);
+		setDataSource('session');
 	}
 
 	function clearPlayerData() {
@@ -293,11 +152,175 @@ const PlayerToolsPage = () => {
 		[setPlayerData, setInputPlayerData, setStrippedPlayerData]
 			.forEach(setFn => { setFn(undefined); });
 	}
+}
 
-	function exportCrewTool() {
-		let text = exportCrew(playerData.player.character.crew.concat(playerData.player.character.unOwnedCrew));
-		downloadData(`data:text/csv;charset=utf-8,${encodeURIComponent(text)}`, 'crew.csv');
-	}
+type PlayerToolsPanesProps = {
+	playerData: any;
+	strippedPlayerData: any;
+	voyageData: any;
+	eventData: any;
+	dataSource: string;
+	allCrew: [];
+	allItems?: any;
+	requestShowForm: (showForm: boolean) => void;
+	requestClearData: () => void;
+};
+
+const PlayerToolsPanes = (props: PlayerToolsPanesProps) => {
+	const { playerData, strippedPlayerData, voyageData, eventData, dataSource,
+			allCrew, allItems, requestShowForm, requestClearData } = props;
+
+	const [activeIndex, setActiveIndex] = useStateWithStorage('tools/activeIndex', 0);
+	const [showIfStale, setShowIfStale] = useStateWithStorage('tools/showStale', true);
+
+	const [showShare, setShowShare] = useStateWithStorage(playerData.player.dbid+'/tools/showShare', true, { rememberForever: true });
+	const [profileAutoUpdate, setProfileAutoUpdate] = useStateWithStorage(playerData.player.dbid+'/tools/profileAutoUpdate', false, { rememberForever: true });
+	const [profileUploaded, setProfileUploaded] = React.useState(false);
+	const [profileUploading, setProfileUploading] = React.useState(false);
+
+	React.useEffect(() => {
+		if (dataSource == 'input' && profileAutoUpdate && !profileUploaded) {
+			console.log('Uploading profile');
+			shareProfile();
+		}
+	}, [profileAutoUpdate, strippedPlayerData]);
+
+	const handleTabChange = (e, { activeIndex }) => setActiveIndex(activeIndex);
+	const panes = [
+		{
+			menuItem: 'Voyage Calculator',
+			render: () => <VoyageCalculator playerData={playerData} voyageData={voyageData} eventData={eventData} />
+		},
+		{
+			menuItem: 'Crew',
+			render: () => <ProfileCrew playerData={playerData} isTools={true} />
+		},
+		{
+			menuItem: 'Crew (mobile)',
+			render: () => <ProfileCrewMobile playerData={playerData} isMobile={false} />
+		},
+		{
+			menuItem: 'Crew Retrieval',
+			render: () => <CrewRetrieval playerData={playerData} />
+		},
+		{
+			menuItem: 'Ships',
+			render: () => <ProfileShips playerData={playerData} />
+		},
+		{
+			menuItem: 'Items',
+			render: () => <ProfileItems playerData={playerData} />
+		},
+		{
+			menuItem: 'Unneeded Items',
+			render: () => <UnneededItems playerData={playerData} />
+		},
+		{
+			menuItem: 'Other',
+			render: () => <ProfileOther playerData={playerData} />
+		},
+		{
+			menuItem: 'Charts & Stats',
+			render: () => <ProfileCharts playerData={playerData} />
+		}
+	];
+
+	const StaleMessage = () => {
+		const STALETHRESHOLD = 3;	// in hours
+		if (showIfStale && new Date().getTime()-playerData.calc.lastModified.getTime() > STALETHRESHOLD*60*60*1000) {
+			return (
+				<Message
+					warning
+					icon='clock'
+					header='Update your player data'
+					content="It's been a few hours since you last updated your player data. We recommend that you update now to make sure our tools are providing you recent information about your crew."
+					onDismiss={() => setShowIfStale(false)}
+				/>
+			);
+		}
+		else {
+			return (<></>);
+		}
+	};
+
+	const ShareMessage = () => {
+		if (!showShare) return (<></>);
+
+		// The option to auto-share profile only appears after a profile is uploaded or if previously set to auto-update
+		const bShowUploaded = profileUploaded || profileAutoUpdate;
+
+		return (
+			<Message icon onDismiss={() => setShowShare(false)}>
+				<Icon name='share alternate' />
+				<Message.Content>
+					<Message.Header>Share your player profile!</Message.Header>
+					{!bShowUploaded && (
+						<div>
+							<p>
+								Click here to{' '}
+								<Button size='small' color='green' onClick={() => shareProfile()}>
+									{profileUploading && <Icon loading name='spinner' />}share your profile
+									</Button>{' '}
+									and unlock more tools and export options for items and ships. More details:
+							</p>
+							<Message.List>
+								<Message.Item>
+									Once shared, the profile will be publicly accessible by anyone that has the link (or knows your DBID)
+									</Message.Item>
+								<Message.Item>
+									There is no private information included in the player profile; information being shared is limited to:{' '}
+									<b>captain name, level, vip level, fleet name and role, achievements, completed missions, your crew, items and ships.</b>
+								</Message.Item>
+							</Message.List>
+						</div>
+					)}
+					{bShowUploaded && (
+						<Form.Group>
+							<p>
+								Your profile was uploaded. Share the link:{' '}
+								<a
+									href={`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}
+									target='_blank'>{`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}</a>
+							</p>
+							<Form.Field
+								control={Checkbox}
+								label='Automatically share profile after every import'
+								checked={profileAutoUpdate}
+								onChange={(e, { checked }) => setProfileAutoUpdate(checked)}
+							/>
+						</Form.Group>
+					)}
+				</Message.Content>
+			</Message>
+		);
+	};
+
+	return (
+		<Layout title='Player tools'>
+			<Header as='h4'>Hello, {playerData.player.character.display_name}</Header>
+
+			<StaleMessage />
+
+			<Menu compact stackable>
+				<Menu.Item>
+					Last imported: {playerData.calc.lastModified.toLocaleString()}
+				</Menu.Item>
+				<Dropdown item text='Profile options'>
+					<Dropdown.Menu>
+						<Dropdown.Item onClick={() => requestShowForm(true)}>Update now...</Dropdown.Item>
+						{!showShare && (<Dropdown.Item onClick={() => setShowShare(true)}>Share profile...</Dropdown.Item>)}
+						<Dropdown.Item onClick={() => requestClearData()}>Clear player data</Dropdown.Item>
+					</Dropdown.Menu>
+				</Dropdown>
+				<Button onClick={() => exportCrewTool()} content='Export crew spreadsheet...' />
+			</Menu>
+
+			<ShareMessage />
+
+			<Tab menu={{ secondary: true, pointing: true }} panes={panes} style={{ marginTop: '1em' }}
+				activeIndex={activeIndex} onTabChange={handleTabChange} />
+		</Layout>
+	);
 
 	function shareProfile() {
 		setProfileUploading(true);
@@ -319,10 +342,15 @@ const PlayerToolsPage = () => {
 			setProfileUploaded(true);
 		});
 	}
+
+	function exportCrewTool() {
+		let text = exportCrew(playerData.player.character.crew.concat(playerData.player.character.unOwnedCrew));
+		downloadData(`data:text/csv;charset=utf-8,${encodeURIComponent(text)}`, 'crew.csv');
+	}
 }
 
 type PlayerToolsFormProps = {
-	setValidInput: fn;
+	setValidInput: (playerData: any) => void;
 };
 
 const PlayerToolsForm = (props: PlayerToolsFormProps) => {

--- a/src/pages/playertools.tsx
+++ b/src/pages/playertools.tsx
@@ -15,161 +15,57 @@ import UnneededItems from '../components/unneededitems';
 
 import { exportCrew, downloadData, prepareProfileData } from '../utils/crewutils';
 import { stripPlayerData } from '../utils/playerutils';
+import { useStateWithStorage } from '../utils/storage';
 
-type PlayerToolsPageProps = {};
+const PlayerToolsPage = () => {
+	const [playerData, setPlayerData] = React.useState(undefined);
+	const [inputPlayerData, setInputPlayerData] = React.useState(undefined);
 
-type PlayerToolsPageState = {
-	playerData?: any;
-	inputPlayerData?: any;
-	strippedPlayerData?: any;
-	errorMessage?: string;
-	fullInput: string | number;
-	displayedInput: string | number;
-	profileUploading: boolean;
-	profileUploaded: boolean;
-	voyageData?: any;
-	eventData?: any;
-};
+	// allCrew will always be set and can be passed as a prop to subcomponents that need it, saving a fetch to crew.json
+	// allItems is NOT always set; it can be passed to subcomponents but requires a check to see if defined
+	const [allCrew, setAllCrew] = React.useState(undefined);
+	const [allItems, setAllItems] = React.useState(undefined);
 
-const PLAYERLINK = 'https://stt.disruptorbeam.com/player?client_api=17';
+	const [strippedPlayerData, setStrippedPlayerData] = useStateWithStorage('toolsPlayerData', undefined);
+	const [voyageData, setVoyageData] = useStateWithStorage('toolsVoyageData', undefined);
+	const [eventData, setEventData] = useStateWithStorage('toolsEventData', undefined);
+	const [activeIndex, setActiveIndex] = useStateWithStorage('toolsActiveIndex', 0);
+	const [showShare, setShowShare] = useStateWithStorage('toolsShowShare', true, { rememberForever: true });
 
-const asyncSessionStorage = {
-	setItem: async function (key, value) {
-		await null;
-		return sessionStorage.setItem(key, value);
-	},
-	getItem: async function (key) {
-		await null;
-		return sessionStorage.getItem(key);
-	},
-	clear: async function () {
-		await null;
-		return sessionStorage.clear();
-	}
-};
+	const [showForm, setShowForm] = React.useState(false);
 
-class PlayerToolsPage extends Component<PlayerToolsPageProps, PlayerToolsPageState> {
-	constructor(props: PlayerToolsPageProps) {
-		super(props);
-
-		this.state = {
-			playerData: undefined,
-			inputPlayerData: undefined,
-			strippedPlayerData: undefined,
-			errorMessage: undefined,
-			fullInput: '',
-			displayedInput: '',
-			profileUploading: false,
-			profileUploaded: false,
-			voyageData: undefined,
-			eventData: undefined
-		};
+	// Profile data ready, show player tool panes
+	if (playerData && !showForm) {
+		return renderTools();
 	}
 
-	async componentDidMount() {
-		let strippedPlayerData = await asyncSessionStorage.getItem('playerData');
-		if (strippedPlayerData) {
-			let voyageData = await asyncSessionStorage.getItem('voyageData');
-			let eventData = await asyncSessionStorage.getItem('eventData');
-			strippedPlayerData = JSON.parse(strippedPlayerData);
-			if (voyageData) voyageData = JSON.parse(voyageData);
-			if (eventData) eventData = JSON.parse(eventData);
-			this.setState({ strippedPlayerData, voyageData, eventData });
+	// Preparing profile data, show spinner
+	if ((inputPlayerData || strippedPlayerData) && !showForm) {
+		if (inputPlayerData) {
+			if (allCrew && allItems)
+				prepareProfileDataFromInput();
+			else if (!allItems)
+				fetchAllItemsAndCrew();
 		}
-	}
-
-	componentDidUpdate() {
-		if (!this.state.playerData && this.state.inputPlayerData)
-			this._prepareProfileDataFromInput();
-		else if (!this.state.playerData && this.state.strippedPlayerData) {
-			this._prepareProfileDataFromSession();
+		else {
+			if (allCrew)
+				prepareProfileDataFromSession();
+			else
+				fetchAllCrew();
 		}
+		return renderSpinner();
 	}
 
-	async _prepareProfileDataFromInput() {
-		const { inputPlayerData } = this.state;
+	// No data available, show input form
+	return (<PlayerToolsForm setValidInput={setValidInput} />);
 
-		const [crewResponse, itemsResponse] = await Promise.all([
-			fetch('/structured/crew.json'),
-			fetch('/structured/items.json')
-		]);
-
-		const allcrew = await crewResponse.json();
-		const allitems = await itemsResponse.json();
-
-		// Crew on shuttles, voyage data, and event data will be stripped from playerData,
-		//	so keep a copy for voyage calculator here
-		//	Event data is not player-specific, so we should find a way to get that outside of playerData
-		let shuttleCrew = [];
-		inputPlayerData.player.character.crew.forEach(crew => {
-			if (crew.active_id > 0) {
-				// Stripped data doesn't include crewId, so create pseudoId based on level and equipment
-				let shuttleCrewId = crew.symbol + ',' + crew.level + ',';
-				crew.equipment.forEach(equipment => shuttleCrewId += equipment[0]);
-				shuttleCrew.push(shuttleCrewId);
-			}
-		});
-		let voyageData = {
-			voyage_descriptions: JSON.parse(JSON.stringify(inputPlayerData.player.character.voyage_descriptions)),
-			voyage: JSON.parse(JSON.stringify(inputPlayerData.player.character.voyage)),
-			shuttle_crew: shuttleCrew
-		}
-		let eventData = JSON.parse(JSON.stringify(inputPlayerData.player.character.events));
-
-		let dtImported = new Date();
-
-		// strippedPlayerData is used for any storage purpose, i.e. sharing profile and keeping in session
-		let strippedPlayerData = stripPlayerData(allitems, JSON.parse(JSON.stringify(inputPlayerData)));
-		strippedPlayerData.calc = { 'lastImported': dtImported };
-
-		// preparedProfileData is expanded with useful data and helpers for DataCore and hopefully generated once
-		//	so other components don't have to keep calculating the same data
-		let preparedProfileData = JSON.parse(JSON.stringify(strippedPlayerData));
-		prepareProfileData(allcrew, preparedProfileData, dtImported);
-
-		// Store strippedPlayerData in session, so user doesn't have to re-import after leaving playertools page
-		//	Must also store voyage and event data for voyage calculator
-		asyncSessionStorage.setItem('playerData', JSON.stringify(strippedPlayerData));
-		asyncSessionStorage.setItem('voyageData', JSON.stringify(voyageData));
-		asyncSessionStorage.setItem('eventData', JSON.stringify(eventData));
-
-		// After this point, playerData should always be preparedProfileData, here and in all components
-		this.setState({ playerData: preparedProfileData, strippedPlayerData, voyageData, eventData });
-	}
-
-	async _prepareProfileDataFromSession() {
-		const { strippedPlayerData } = this.state;
-
-		const [crewResponse] = await Promise.all([
-			fetch('/structured/crew.json'),
-		]);
-
-		const allcrew = await crewResponse.json();
-
-		let preparedProfileData = JSON.parse(JSON.stringify(strippedPlayerData));
-		prepareProfileData(allcrew, preparedProfileData, new Date(Date.parse(strippedPlayerData.calc.lastImported)));
-
-		this.setState({ playerData: preparedProfileData });
-	}
-
-	render() {
-		const { playerData, inputPlayerData, strippedPlayerData } = this.state;
-
-		if (!playerData && (inputPlayerData || strippedPlayerData)) {
-			return (
-				<Layout title='Player tools'>
-					<Icon loading name='spinner' /> Loading...
-				</Layout>
-			);
-		}
-
-		if (!playerData)
-			return this.renderInputForm();
+	function renderTools() {
+		const handleTabChange = (e, { activeIndex }) => setActiveIndex(activeIndex);
 
 		const panes = [
 			{
 				menuItem: 'Voyage Calculator',
-				render: () => <VoyageCalculator playerData={playerData} voyageData={this.state.voyageData} eventData={this.state.eventData} />
+				render: () => <VoyageCalculator playerData={playerData} voyageData={voyageData} eventData={eventData} />
 			},
 			{
 				menuItem: 'Crew',
@@ -205,79 +101,190 @@ class PlayerToolsPage extends Component<PlayerToolsPageProps, PlayerToolsPageSta
 			}
 		];
 
+		const StaleMessage = () => {
+			const STALETHRESHOLD = 1;	// in hours
+			if (new Date().getTime()-playerData.calc.lastModified.getTime() > STALETHRESHOLD*60*60*1000) {
+				return (
+					<Message
+						warning
+						icon='clock'
+						header='Update your player data'
+						content="It's been a few hours since you last updated your player data. We recommend that you update now to make sure our tools are providing you recent information about your crew."
+					/>
+				);
+			}
+			else {
+				return (<></>);
+			}
+		};
+
 		return (
 			<Layout title='Player tools'>
 				<Header as='h4'>Hello, {playerData.player.character.display_name}</Header>
-				<Message icon>
-					<Icon name='bell' />
-					<Message.Content>
-						<Message.Header>Share your player profile!</Message.Header>
-						{!this.state.profileUploaded && (
-							<p>
-								Click here to{' '}
-								<Button size='small' color='green' onClick={() => this._shareProfile()}>
-									{this.state.uploading && <Icon loading name='spinner' />}share your profile
-									</Button>{' '}
-									and unlock more tools and export options for items and ships. More details:
-							</p>
-						)}
-						{!this.state.profileUploaded && (
-							<Message.List>
-								<Message.Item>
-									Once shared, the profile will be publicly accessible by anyone that has the link (or knows your DBID)
-									</Message.Item>
-								<Message.Item>
-									There is no private information included in the player profile; information being shared is limited to:{' '}
-									<b>captain name, level, vip level, fleet name and role, achievements, completed missions, your crew, items and ships.</b>
-								</Message.Item>
-							</Message.List>
-						)}
-						{this.state.profileUploaded && (
-							<p>
-								Your profile was uploaded. Share the link:{' '}
-								<a
-									href={`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}
-									target='_blank'>{`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}</a>
-							</p>
-						)}
-					</Message.Content>
-				</Message>
 
-				<Menu compact>
-					{playerData.calc.lastModified && (
-						<Dropdown item text={`Player data imported: ${playerData.calc.lastModified.toLocaleString()}`}>
-							<Dropdown.Menu>
-								<Dropdown.Item onClick={() => this._forceInputForm()}>Update now...</Dropdown.Item>
-								<Dropdown.Item onClick={() => this._clearPlayerData()}>Clear player data</Dropdown.Item>
-							</Dropdown.Menu>
-						</Dropdown>
-					)}
-					<Button onClick={() => this._exportCrew()} content='Export crew spreadsheet...' />
+				<StaleMessage />
+				<Menu compact stackable>
+					<Menu.Item>
+						Last imported: {playerData.calc.lastModified.toLocaleString()}
+					</Menu.Item>
+					<Dropdown item text='Profile options'>
+						<Dropdown.Menu>
+							<Dropdown.Item onClick={() => setShowForm(true)}>Update now...</Dropdown.Item>
+							{!showShare && (<Dropdown.Item onClick={() => setShowShare(true)}>Share profile...</Dropdown.Item>)}
+							<Dropdown.Item onClick={() => clearPlayerData()}>Clear player data</Dropdown.Item>
+						</Dropdown.Menu>
+					</Dropdown>
+					<Button onClick={() => exportCrewTool()} content='Export crew spreadsheet...' />
 				</Menu>
 
-				<Tab menu={{ secondary: true, pointing: true }} panes={panes} style={{ marginTop: '1em' }} />
+				{showShare && (<PlayerToolsShare playerData={playerData} strippedPlayerData={strippedPlayerData} setShowShare={setShowShare} />)}
+
+				<Tab menu={{ secondary: true, pointing: true }} panes={panes} style={{ marginTop: '1em' }}
+					activeIndex={activeIndex} onTabChange={handleTabChange} />
 			</Layout>
 		);
 	}
 
-	_clearPlayerData() {
-		asyncSessionStorage.clear();
-		this._forceInputForm();
+	function renderSpinner() {
+		return (
+			<Layout title='Player tools'>
+				<Icon loading name='spinner' /> Loading...
+			</Layout>
+		);
 	}
 
-	_forceInputForm() {
-		this.setState({
-			playerData: undefined,
-			inputPlayerData: undefined,
-			strippedPlayerData: undefined,
-			fullInput: '',
-			displayedInput: ''
+	function setValidInput(inputData : any) {
+		setPlayerData(undefined);
+		setInputPlayerData(inputData);
+		setShowForm(false);
+	}
+
+	async function fetchAllItemsAndCrew() {
+		const [itemsResponse, crewResponse] = await Promise.all([
+			fetch('/structured/items.json'),
+			fetch('/structured/crew.json')
+		]);
+		const [allitems, allcrew] = await Promise.all([
+			itemsResponse.json(),
+			crewResponse.json()
+		]);
+		setAllItems(allitems);
+		setAllCrew(allcrew);
+	}
+
+	// Only crew data is needed if loading profile from session
+	//	Does this really save any time, or should we just use fetchAllItemsAndCrew every time playertools is loaded?
+	async function fetchAllCrew() {
+		const crewResponse = await fetch('/structured/crew.json');
+		const allcrew = await crewResponse.json();
+		setAllCrew(allcrew);
+	}
+
+	function prepareProfileDataFromInput() {
+		// Crew on shuttles, voyage data, and event data will be stripped from playerData,
+		//	so keep a copy for voyage calculator here
+		//	Event data is not player-specific, so we should find a way to get that outside of playerData
+		let shuttleCrew = [];
+		inputPlayerData.player.character.crew.forEach(crew => {
+			if (crew.active_id > 0) {
+				// Stripped data doesn't include crewId, so create pseudoId based on level and equipment
+				let shuttleCrewId = crew.symbol + ',' + crew.level + ',';
+				crew.equipment.forEach(equipment => shuttleCrewId += equipment[0]);
+				shuttleCrew.push(shuttleCrewId);
+			}
 		});
+		let voyageData = {
+			voyage_descriptions: [...inputPlayerData.player.character.voyage_descriptions],
+			voyage: [...inputPlayerData.player.character.voyage],
+			shuttle_crew: shuttleCrew
+		}
+		setVoyageData(voyageData);
+		setEventData([...inputPlayerData.player.character.events]);
+
+		let dtImported = new Date();
+
+		// strippedPlayerData is used for any storage purpose, i.e. sharing profile and keeping in session
+		let strippedData = stripPlayerData(allItems, {...inputPlayerData});
+		strippedData.calc = { 'lastImported': dtImported };
+		setStrippedPlayerData(JSON.parse(JSON.stringify(strippedData)));
+
+		// preparedProfileData is expanded with useful data and helpers for DataCore and hopefully generated once
+		//	so other components don't have to keep calculating the same data
+		// After this point, playerData should always be preparedProfileData, here and in all components
+		let preparedProfileData = {...strippedData};
+		prepareProfileData(allCrew, preparedProfileData, dtImported);
+		setPlayerData(preparedProfileData);
 	}
 
-	_shareProfile() {
-		this.setState({ profileUploading: true });
-		const { playerData, strippedPlayerData } = this.state;
+	function prepareProfileDataFromSession() {
+		let preparedProfileData = {...strippedPlayerData};
+		prepareProfileData(allCrew, preparedProfileData, new Date(Date.parse(strippedPlayerData.calc.lastImported)));
+		setPlayerData(preparedProfileData);
+	}
+
+	function clearPlayerData() {
+		sessionStorage.clear();	// also clears form data for all subcomponents
+		[setPlayerData, setInputPlayerData, setStrippedPlayerData]
+			.forEach(setFn => { setFn(undefined); });
+	}
+
+	function exportCrewTool() {
+		let text = exportCrew(playerData.player.character.crew.concat(playerData.player.character.unOwnedCrew));
+		downloadData(`data:text/csv;charset=utf-8,${encodeURIComponent(text)}`, 'crew.csv');
+	}
+}
+
+type PlayerToolsShareProps = {
+	playerData: any;
+	strippedPlayerData: any;
+	setShowShare: fn;
+};
+
+const PlayerToolsShare = (props: PlayerToolsShareProps) => {
+	const { playerData, strippedPlayerData, setShowShare } = props;
+
+	const [profileUploaded, setProfileUploaded] = React.useState(false);
+	const [profileUploading, setProfileUploading] = React.useState(false);
+
+	return (
+		<Message icon onDismiss={handleDismiss}>
+			<Icon name='bell' />
+			<Message.Content>
+				<Message.Header>Share your player profile!</Message.Header>
+				{!profileUploaded && (
+					<p>
+						Click here to{' '}
+						<Button size='small' color='green' onClick={() => shareProfile()}>
+							{profileUploading && <Icon loading name='spinner' />}share your profile
+							</Button>{' '}
+							and unlock more tools and export options for items and ships. More details:
+					</p>
+				)}
+				{!profileUploaded && (
+					<Message.List>
+						<Message.Item>
+							Once shared, the profile will be publicly accessible by anyone that has the link (or knows your DBID)
+							</Message.Item>
+						<Message.Item>
+							There is no private information included in the player profile; information being shared is limited to:{' '}
+							<b>captain name, level, vip level, fleet name and role, achievements, completed missions, your crew, items and ships.</b>
+						</Message.Item>
+					</Message.List>
+				)}
+				{profileUploaded && (
+					<p>
+						Your profile was uploaded. Share the link:{' '}
+						<a
+							href={`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}
+							target='_blank'>{`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`}</a>
+					</p>
+				)}
+			</Message.Content>
+		</Message>
+	);
+
+	function shareProfile() {
+		setProfileUploading(true);
 
 		let jsonBody = JSON.stringify({
 			dbid: playerData.player.dbid,
@@ -292,120 +299,173 @@ class PlayerToolsPage extends Component<PlayerToolsPageProps, PlayerToolsPageSta
 			body: jsonBody
 		}).then(() => {
 			window.open(`${process.env.GATSBY_DATACORE_URL}profile/?dbid=${playerData.player.dbid}`, '_blank');
-			this.setState({ profileUploading: false, profileUploaded: true });
+			setProfileUploading(false);
+			setProfileUploaded(true);
 		});
 	}
 
-	_exportCrew() {
-		const { playerData } = this.state;
-
-		let text = exportCrew(playerData.player.character.crew.concat(playerData.player.character.unOwnedCrew));
-		downloadData(`data:text/csv;charset=utf-8,${encodeURIComponent(text)}`, 'crew.csv');
+	function handleDismiss() {
+		setShowShare(false);
 	}
+};
 
-	renderInputForm() {
-		const { errorMessage } = this.state;
+type PlayerToolsFormProps = {
+	setValidInput: fn;
+};
 
-		return (
-			<Layout>
-				<Container style={{ paddingBottom: '2em' }}>
-					<Header as='h4'>Player tools</Header>
-					<p>You can access some of your player data from the game's website and import it here to calculate optimal voyage lineups, identify unnecessary items, export your crew list as a CSV, or share your profile with other players, among other tools. This website cannot make direct requests to the game's servers due to security configurations and unclear terms of service interpretations, so there are a few manual steps required to import your data.</p>
-					<p>If you have multiple accounts, we recommend using your browser in InPrivate mode (Edge) or Incognito mode (Firefox / Chrome) to avoid caching your account credentials, making it easier to change accounts.</p>
-					<ul>
-						<li>
-							Open this page in your browser:{' '}
-							<a href={PLAYERLINK} target='_blank'>
-								https://stt.disruptorbeam.com/player
-								</a>
-						</li>
-						<li>
-							Log in if asked, then wait for the page to finish loading. It should start with:{' '}
-							<span style={{ fontFamily: 'monospace' }}>{'{"action":"update","player":'}</span> ...
-							</li>
-						<li>Select everything in the page (Ctrl+A) and copy it (Ctrl+C)</li>
-						<li>Paste it (Ctrl+V) in the text box below. Note that only the first few lines may be displayed</li>
-						<li>Click the 'Import data' button</li>
-					</ul>
+const PlayerToolsForm = (props: PlayerToolsFormProps) => {
+	const PLAYERLINK = 'https://stt.disruptorbeam.com/player?client_api=17';
 
-					<Form>
-						<TextArea
-							placeholder='Paste your player data here'
-							value={this.state.displayedInput}
-							onChange={(e, { value }) => this.setState({ displayedInput: value })}
-							onPaste={(e) => { return this._onPaste(e) }}
-						/>
-						<input
-							type='file'
-							onChange={(e) => { this._handleFileUpload(e) }}
-							style={{ display: 'none' }}
-							ref={e => this.inputUploadFile = e}
-						/>
-					</Form>
+	const { setValidInput } = props;
 
-					<Button
-						onClick={() => this._parseInput()}
-						style={{ marginTop: '1em' }}
-						content='Import data'
-						icon='paste'
-						labelPosition='right'
-					/>
+	const [inputPlayerData, setInputPlayerData] = React.useState(undefined);
+	const [fullInput, setFullInput] = React.useState('');
+	const [displayedInput, setDisplayedInput] = React.useState('');
+	const [errorMessage, setErrorMessage] = React.useState(undefined);
 
-					{errorMessage && (
-						<Message negative>
-							<Message.Header>Error</Message.Header>
-							<p>{errorMessage}</p>
-						</Message>
-					)}
-				</Container>
+	let inputUploadFile = null;
 
-				<p>To circumvent the long text copy limitations on mobile devices, download{' '}
-					<a href={PLAYERLINK} target='_blank'>
-						your player data
+	if (fullInput != "")
+		parseInput();
+
+	React.useEffect(() => {
+		if (inputPlayerData) {
+			setValidInput(inputPlayerData);
+			setInputPlayerData(undefined);
+		}
+	}, [inputPlayerData]);
+
+	return (
+		<Layout>
+			<Container style={{ paddingBottom: '2em' }}>
+				<Header as='h2'>Player tools</Header>
+				<p>You can access some of your player data from the game's website and import it here to calculate optimal voyage lineups, identify unnecessary items, export your crew list as a CSV, or share your profile with other players, among other tools. This website cannot make direct requests to the game's servers due to security configurations and unclear terms of service interpretations, so there are a few manual steps required to import your data.</p>
+				<p>If you have multiple accounts, we recommend using your browser in InPrivate mode (Edge) or Incognito mode (Firefox / Chrome) to avoid caching your account credentials, making it easier to change accounts.</p>
+				<ul>
+					<li>
+						Open this page in your browser:{' '}
+						<a href={PLAYERLINK} target='_blank'>
+							https://stt.disruptorbeam.com/player
 							</a>
-					{' '}to your device, then click the 'Upload data file' button.
-						</p>
-				<p>
-					<Modal
-						trigger={<a href="#">Click here for detailed instructions for Apple iOS devices.</a>}
-						header='Player data upload on iOS'
-						content={<ul>
-							<li>Go to your player data using the link provided, logging in if asked.</li>
-							<li>Wait for the page to finish loading. It should start with:{' '}
-								<span style={{ fontFamily: 'monospace' }}>{'{"action":"update","player":'}</span> ...
-									</li>
-							<li>Press the share icon while viewing the page.</li>
-							<li>Tap 'options' and choose 'Web Archive', tap 'save to files', choose a location and save.</li>
-							<li>Come back to this page (DataCore.app player tools).</li>
-							<li>Tap the 'Upload data file' button.</li>
-							<li>Choose the file starting with 'player?client_api...' from where you saved it.</li>
-						</ul>}
+					</li>
+					<li>
+						Log in if asked, then wait for the page to finish loading. It should start with:{' '}
+						<span style={{ fontFamily: 'monospace' }}>{'{"action":"update","player":'}</span> ...
+						</li>
+					<li>Select everything in the page (Ctrl+A) and copy it (Ctrl+C)</li>
+					<li>Paste it (Ctrl+V) in the text box below. Note that only the first few lines may be displayed</li>
+					<li>Click the 'Import data' button</li>
+				</ul>
+
+				<Form>
+					<TextArea
+						placeholder='Paste your player data here'
+						value={displayedInput}
+						onChange={(e, { value }) => setDisplayedInput(value)}
+						onPaste={(e) => { return onInputPaste(e) }}
 					/>
-				</p>
+					<input
+						type='file'
+						onChange={(e) => { handleFileUpload(e) }}
+						style={{ display: 'none' }}
+						ref={e => inputUploadFile = e}
+					/>
+				</Form>
 
 				<Button
-					onClick={() => this.inputUploadFile.click()}
-					content='Upload data file'
-					icon='file'
+					onClick={() => parseInput()}
+					style={{ marginTop: '1em' }}
+					content='Import data'
+					icon='paste'
 					labelPosition='right'
 				/>
-			</Layout>
-		);
+
+				{errorMessage && (
+					<Message negative>
+						<Message.Header>Error</Message.Header>
+						<p>{errorMessage}</p>
+					</Message>
+				)}
+			</Container>
+
+			<p>To circumvent the long text copy limitations on mobile devices, download{' '}
+				<a href={PLAYERLINK} target='_blank'>
+					your player data
+						</a>
+				{' '}to your device, then click the 'Upload data file' button.
+					</p>
+			<p>
+				<Modal
+					trigger={<a href="#">Click here for detailed instructions for Apple iOS devices.</a>}
+					header='Player data upload on iOS'
+					content={<ul>
+						<li>Go to your player data using the link provided, logging in if asked.</li>
+						<li>Wait for the page to finish loading. It should start with:{' '}
+							<span style={{ fontFamily: 'monospace' }}>{'{"action":"update","player":'}</span> ...
+								</li>
+						<li>Press the share icon while viewing the page.</li>
+						<li>Tap 'options' and choose 'Web Archive', tap 'save to files', choose a location and save.</li>
+						<li>Come back to this page (DataCore.app player tools).</li>
+						<li>Tap the 'Upload data file' button.</li>
+						<li>Choose the file starting with 'player?client_api...' from where you saved it.</li>
+					</ul>}
+				/>
+			</p>
+
+			<Button
+				onClick={() => inputUploadFile.click()}
+				content='Upload data file'
+				icon='file'
+				labelPosition='right'
+			/>
+		</Layout>
+	);
+
+	function parseInput() {
+		let testInput = fullInput;
+
+		// Use inputted text if no pasted text detected
+		if (testInput == '') testInput = displayedInput;
+
+		try {
+			let testData = JSON.parse(testInput as string);
+
+			if (testData && testData.player && testData.player.display_name) {
+				if (testData.player.character && testData.player.character.crew && (testData.player.character.crew.length > 0)) {
+					setInputPlayerData(testData);
+					setDisplayedInput('');
+					setErrorMessage(undefined);
+				} else {
+					setErrorMessage('Failed to parse player data from the text you pasted. Make sure you are logged in with the correct account.');
+				}
+			} else {
+				setErrorMessage('Failed to parse player data from the text you pasted. Make sure the page is loaded correctly and you copied the entire contents!');
+			}
+		} catch (err) {
+			if ((/Log in to CS Tools/).test(testInput)) {
+				setErrorMessage('You are not logged in! Open the player data link above and log in to the game as instructed. Then return to this DataCore page and repeat all the steps to import your data.');
+			}
+			else {
+				setErrorMessage(`Failed to read the data. Make sure the page is loaded correctly and you copied the entire contents! (${err})`);
+			}
+		}
+
+		setFullInput('');
 	}
 
-	_onPaste(event) {
+	function onInputPaste(event) {
 		let paste = event.clipboardData || window.clipboardData;
 		if (paste) {
-			let fullInput = paste.getData('text');
-			let displayedInput = fullInput.substr(0, 500) + ' [ ... ]';
-			this.setState({ fullInput, displayedInput });
+			let fullPaste = paste.getData('text');
+			setFullInput(fullPaste);
+			setDisplayedInput(fullPaste.substr(0, 500)+' [ ... ]');
 			event.preventDefault();
 			return false;
 		}
 		return true;
 	}
 
-	_handleFileUpload(event) {
+	function handleFileUpload(event) {
 		// use FileReader to read file content in browser
 		const fReader = new FileReader();
 		fReader.onload = (e) => {
@@ -415,38 +475,10 @@ class PlayerToolsPage extends Component<PlayerToolsPageProps, PlayerToolsPageSta
 				// Find where the JSON begins and ends, and extract just that from the larger string.
 				data = data.substring(data.indexOf('{'), data.lastIndexOf('}}') + 2);
 			}
-			this.setState({ fullInput: data });
-			this._parseInput();
+			setFullInput(data);
 		};
 		fReader.readAsText(event.target.files[0]);
 	}
-
-	_parseInput() {
-		// Use inputted text if no pasted text detected
-		if (this.state.fullInput == '')
-			this.setState({ fullInput: this.state.displayedInput });
-
-		try {
-			let playerData = JSON.parse(this.state.fullInput as string);
-
-			if (playerData && playerData.player && playerData.player.display_name) {
-				if (playerData.player.character && playerData.player.character.crew && (playerData.player.character.crew.length > 0)) {
-					this.setState({ inputPlayerData: playerData, errorMessage: undefined });
-				} else {
-					this.setState({ errorMessage: 'Failed to parse player data from the text you pasted. Make sure you are logged in with the correct account.' });
-				}
-			} else {
-				this.setState({
-					errorMessage:
-						'Failed to parse player data from the text you pasted. Make sure the page is loaded correctly and you copied the entire contents!'
-				});
-			}
-		} catch (err) {
-			this.setState({
-				errorMessage: `Failed to read the data. Make sure the page is loaded correctly and you copied the entire contents! (${err})`
-			});
-		}
-	}
-}
+};
 
 export default PlayerToolsPage;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -3,45 +3,91 @@ import * as localForage from 'localforage';
 
 interface StorageOptions {
 	rememberForever?: boolean;	// We store in session unless told to remember forever
-	useDefault?: boolean;	// Use default value as initial value instead of any stored value
-	useAndStoreDefault?: boolean;	// Use default and store it immediately to avoid render loops
-}
+	useDefault?: boolean;	// Set to true to use default value as initial value instead of any stored value
+	useAndStoreDefault?: boolean;	// Set to true to use default and store it immediately to avoid render loops
+};
 
 const StorageDefaultOptions: StorageOptions = {
 	rememberForever: false,
 	useDefault: false,
 	useAndStoreDefault: false
-}
+};
 
 export const useStateWithStorage = (itemKey: string, itemDefault: any, options?: StorageOptions) => {
 	if (!options) options = StorageDefaultOptions;
 
-	// Set initial value (either from storage or default value) in state
-	const [value, setValue] = React.useState(() => {
-			if (options.useAndStoreDefault) {
-				storeItem(itemKey, itemDefault, options.rememberForever);
-				return itemDefault;
-			}
-			if (options.useDefault) return itemDefault;
-			return getItem(itemKey, itemDefault, options.rememberForever);
-		}
-	);
+	const ref = React.useRef();
+
+	// Start with default value in state
+	const [value, setValue] = React.useState(itemDefault);
 
 	// Update stored value when value changed in state
-	React.useEffect(() => { storeItem(itemKey, value, options.rememberForever); }, [value]);
+	//	Remove from store (or ignore) if non-initial value is undefined or default
+	React.useEffect(() => {
+		if (value === undefined || value == itemDefault) {
+			if (ref.current != undefined) {
+				removeStoredItem(itemKey, options.rememberForever);
+			}
+		}
+		else {
+			storeItem(itemKey, value, options.rememberForever);
+		}
+		ref.current = value;
+	}, [value]);
+
+	React.useEffect(() => {
+		// On component mount: override stored value if requested
+		if (options.useAndStoreDefault) {
+			setValue(itemDefault);
+		}
+		// Otherwise update value with stored value
+		else if (!options.useDefault) {
+			getStoredItem(itemKey, itemDefault, options.rememberForever).then((storedValue) => {
+				setValue(storedValue);
+			});
+		}
+	}, []);
 
 	return [value, setValue];
 };
 
 // Use JSON.stringify and JSON.parse to preserve item types when storing, getting
-const storeItem = (itemKey: string, itemValue: any, rememberForever: boolean) => {
-	if (rememberForever)
+const storeItem = (itemKey: string, itemValue: any, useLocalStorage: boolean) => {
+	if (useLocalStorage) {
 		localForage.setItem(itemKey, JSON.stringify(itemValue));
-	else
+	}
+	else {
 		sessionStorage.setItem(itemKey, JSON.stringify(itemValue));
+	}
 };
-const getItem = (itemKey: string, itemDefault: any, rememberForever: boolean) => {
-	let storedValue = rememberForever ? localForage.getItem(itemKey) : sessionStorage.getItem(itemKey);
-	if (!storedValue) return itemDefault;
-	return JSON.parse(storedValue);
+const getStoredItem = (itemKey: string, itemDefault: any, useLocalStorage: boolean) => {
+	return new Promise((resolve, reject) => {
+		if (useLocalStorage) {
+			localForage.getItem(itemKey).then((localValue) => {
+				if (!localValue) {
+					resolve(itemDefault);
+				}
+				else {
+					resolve(JSON.parse(localValue));
+				}
+			});
+		}
+		else {
+			let sessionValue = sessionStorage.getItem(itemKey);
+			if (!sessionValue) {
+				resolve(itemDefault);
+			}
+			else {
+				resolve(JSON.parse(sessionValue));
+			}
+		}
+	});
+};
+const removeStoredItem = (itemKey: string, useLocalStorage: boolean) => {
+	if (useLocalStorage) {
+		localForage.removeItem(itemKey);
+	}
+	else {
+		sessionStorage.removeItem(itemKey);
+	}
 };


### PR DESCRIPTION
The player tools page has been refactored (again), this time so we can use React hooks to more easily tie sessionStorage to state. Specifically, this allows player tools to remember the user's last active tool. If a user navigates away from player tools, when they return, they'll be shown the last tool used (instead of the voyage calculator tab by default). When combined with a non-class component that also saves form options in session (currently only the profilecrew tool), this will bring a user back to the exact player tool and form setup that they left. The remembered settings are forgotten when the browser is closed.

Other small enhancements:
After pasting the player data, the import form now automatically tries to parse the data without having to click the import button.

A more informative error is shown if a user tries to import the login page instead of valid player data. See #176

If the player data is stale (i.e. last imported <strike>6 hours</strike> 1 hour ago or more), we now show a warning message recommending the user update now. Edited to add: the stale threshold is currently set to 1 hour, but I was originally thinking it should be set to 6 hours.

The "Update now" and "Clear player data" have been moved to their own dedicated "Profile options" dropdown menu.

The "Share your player profile" message can now be dismissed. If dismissed, it can be shown again from a new command in the aforementioned "Profile options" menu. This dismissed setting should persist across sessions.

Storage util has been updated to retrieve from sessionStorage and localForage asynchronously, better handle undefined values, and to ensure that default values are not stored.