### PR TITLE
Show buffed skill numbers in tools roster views

### DIFF
--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -73,11 +73,11 @@ const ProfileCrew = (props: ProfileCrewProps) => {
 					<Rating icon='star' rating={crew.rarity} maxRating={crew.max_rarity} size="large" disabled />
 				</Table.Cell>
 				{CONFIG.SKILLS_SHORT.map(skill =>
-					crew.base_skills[skill.name] ? (
+					crew[skill.name].core > 0 ? (
 						<Table.Cell key={skill.name} textAlign='center'>
-							<b>{crew.base_skills[skill.name].core}</b>
+							<b>{crew[skill.name].core}</b>
 							<br />
-							+({crew.base_skills[skill.name].range_min}-{crew.base_skills[skill.name].range_max})
+							+({crew[skill.name].min}-{crew[skill.name].max})
 						</Table.Cell>
 					) : (
 						<Table.Cell key={skill.name} />

--- a/src/components/vaultcrew.tsx
+++ b/src/components/vaultcrew.tsx
@@ -17,7 +17,7 @@ type VaultCrewProps = {
 function formatCrewStats(crew: any): JSX.Element {
 	let skills = [];
 	for (let skillName in CONFIG.SKILLS) {
-		let skill = crew.base_skills[skillName];
+		let skill = crew[skillName];
 
 		if (skill && skill.core && skill.core > 0) {
 			let skillShortName = CONFIG.SKILLS_SHORT.find(c => c.name === skillName).short;
@@ -26,7 +26,7 @@ function formatCrewStats(crew: any): JSX.Element {
 					<span>{skillShortName}</span> <b>{skill.core}</b>{' '}
 					<span>
 						{' '}
-						{skill.range_min}-{skill.range_max}
+						{skill.min}-{skill.max}
 					</span>
 				</p>
 			);


### PR DESCRIPTION
Just a quick change to show buffed skill numbers (instead of base skill numbers) in the profile_crew table and the profile_crew2 (mobile) popup. Works for both tools and profiles.

Fwiw: I doublechecked the voyage calculator and it already uses buffed skill numbers. Not sure where else we can use buffs at the moment, so #177 might be done for now?