### PR TITLE
Load dark theme CSS before JS initialises (fixes #188)

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -26,6 +26,7 @@ class Layout extends PureComponent<LayoutProps, LayoutState> {
 							<meta property='og:site_name' content='DataCore' />
 							<meta property='og:image' content={`${data.site.siteMetadata.baseUrl}/media/logo.png`} />
 							<meta property='og:description' content={data.site.siteMetadata.defaultDescription} />
+							<link id='defaultThemeCSS' rel='stylesheet' type='text/css' href={withPrefix('styles/semantic.slate.css')} />
 							<link rel='stylesheet' type='text/css' href={withPrefix('styles/easymde.min.css')} />
 							<script src={withPrefix('styles/theming.js')} type='text/javascript' />
 						</Helmet>


### PR DESCRIPTION
Means people using light theme will see dark theme for a second or two, but this is the best fix, as the alternative would delay time-to-first-paint until after JS loads.