### PR TITLE
Add event phases to event planner

### DIFF
--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -100,6 +100,7 @@ export const SearchableTable = (props: SearchableTableProps) => {
 						width={cell.width as any}
 						sorted={((cell.pseudocolumns && cell.pseudocolumns.includes(column)) || (column === cell.column)) ? direction : null}
 						onClick={() => handleSort(cell.column, cell.pseudocolumns)}
+						textAlign={cell.width == 1 ? 'center' : 'left'}
 					>
 						{cell.title}{cell.pseudocolumns?.includes(column) && <><br/><small>{column}</small></>}
 					</Table.HeaderCell>


### PR DESCRIPTION
Event phase types are now used to calculate bonus skills in the crew table. For hybrid events, you can select which phase you want to see.

The shuttle helper tool will now only be shown if the event is a faction or the selected phase of a hybrid is a faction.

The shuttle helper has split the consider active crew option into 2 mutually exclusive options: consider active shuttle crew and consider active voyage crew.

The event planner now shows the event image of the selected event.

Skill icons are now shown in the event table (instead of skill names) to match the appearance of similar tables on DataCore. The headers of skill columns are now center aligned on every page that also uses the searchabletable component. Note that this may affect other table headings too.