### PR TITLE
Adds combo columns, matrix, prospective crew to event planner

### DIFF
--- a/src/components/eventplanner.tsx
+++ b/src/components/eventplanner.tsx
@@ -12,9 +12,10 @@ import { useStateWithStorage } from '../utils/storage';
 import { calculateBuffConfig } from '../utils/voyageutils';
 
 const tableConfig: ITableConfigRow[] = [
-	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'level'] },
-	{ width: 1, column: 'max_rarity', title: 'Rarity' },
+	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'max_rarity', 'level'] },
 	{ width: 1, column: 'bonus', title: 'Bonus' },
+	{ width: 1, column: 'bestSkill.score', title: 'Best' },
+	{ width: 1, column: 'bestCombo.score', title: 'Combo' },
 	{ width: 1, column: 'command_skill.core', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} /> },
 	{ width: 1, column: 'science_skill.core', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} /> },
 	{ width: 1, column: 'security_skill.core', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} /> },
@@ -27,14 +28,16 @@ type EventPlannerProps = {
 	playerData: any;
 	eventData: any;
 	activeCrew: string[];
+	allCrew: any;
 };
 
 const EventPlanner = (props: EventPlannerProps) => {
-	const { playerData, eventData } = props;
+	const { playerData, eventData, allCrew } = props;
 	const dbid = playerData.player.dbid;
+
 	const activeCrew = JSON.parse(JSON.stringify(props.activeCrew));
 
-	let crewlist = [];
+	let myCrew = [];
 	let fakeID = 1;
 	playerData.player.character.crew.forEach(crew => {
 		let crewman = JSON.parse(JSON.stringify(crew));
@@ -51,7 +54,7 @@ const EventPlanner = (props: EventPlannerProps) => {
 			}
 		}
 
-		crewlist.push(crewman);
+		myCrew.push(crewman);
 	});
 
 	let activeEvents = eventData.filter((ev) => ev.seconds_to_end > 0);
@@ -60,7 +63,7 @@ const EventPlanner = (props: EventPlannerProps) => {
 	let buffConfig = calculateBuffConfig(playerData.player);
 
 	return (
-		<EventPicker dbid={dbid} events={activeEvents} crew={crewlist} buffConfig={buffConfig} />
+		<EventPicker dbid={dbid} events={activeEvents} crew={myCrew} buffConfig={buffConfig} allCrew={allCrew} />
 	);
 };
 
@@ -69,6 +72,7 @@ type EventPickerProps = {
 	events: any[];
 	crew: any[];
 	buffConfig: any;
+	allCrew: any[];
 };
 
 class EventData {
@@ -82,10 +86,11 @@ class EventData {
 };
 
 const EventPicker = (props: EventPickerProps) => {
-	const { dbid, events, crew, buffConfig } = props;
+	const { dbid, events, crew, buffConfig, allCrew } = props;
 
 	const [eventIndex, setEventIndex] = useStateWithStorage('eventplanner/eventIndex', 0);
 	const [phaseIndex, setPhaseIndex] = useStateWithStorage('eventplanner/phaseIndex', 0);
+	const [prospects, setProspects] = useStateWithStorage('eventplanner/prospects', []);
 
 	const eventsList = [];
 	events.forEach((activeEvent, eventId) => {
@@ -119,7 +124,34 @@ const EventPicker = (props: EventPickerProps) => {
 		}
 	});
 
-	const bonusCrew = crew.filter(crewman => eventData.bonus.indexOf(crewman.symbol) >= 0);
+	const allBonusCrew = allCrew.filter((c) => eventData.bonus.indexOf(c.symbol) >= 0);
+	allBonusCrew.sort((a, b)=>a.name.localeCompare(b.name));
+
+	const myCrew = JSON.parse(JSON.stringify(crew));
+
+	prospects.forEach((p) => {
+		let prospect = allCrew.find((c) => c.symbol == p.symbol);
+		if (prospect) {
+			prospect = JSON.parse(JSON.stringify(prospect));
+			prospect.id = myCrew.length+1;
+			prospect.prospect = true;
+			prospect.have = false;
+			prospect.rarity = p.rarity;
+			prospect.level = 100;
+			prospect.immortal = 0;
+			CONFIG.SKILLS_SHORT.forEach(skill => {
+				let score = { "core": 0, "min": 0, "max" : 0 };
+				if (prospect.base_skills[skill.name]) {
+					if (prospect.rarity == prospect.max_rarity)
+						score = applySkillBuff(buffConfig, skill.name, prospect.base_skills[skill.name]);
+					else
+						score = applySkillBuff(buffConfig, skill.name, prospect.skill_data[prospect.rarity-1].base_skills[skill.name]);
+				}
+				prospect[skill.name] = score;
+			});
+			myCrew.push(prospect);
+		}
+	});
 
 	return (
 		<React.Fragment>
@@ -135,8 +167,9 @@ const EventPicker = (props: EventPickerProps) => {
 				<div>{eventData.description}</div>
 				{phaseList.length > 1 && (<div style={{ margin: '1em 0' }}>Select a phase: <Dropdown selection options={phaseList} value={phaseIndex} onChange={(e, { value }) => setPhaseIndex(value) } /></div>)}
 			</Form>
-			<EventCrewTable crew={crew} eventData={eventData} phaseIndex={phaseIndex} buffConfig={buffConfig} />
-			{eventData.content_types[phaseIndex] == 'shuttles' && (<EventShuttlers dbid={dbid} crew={crew} eventData={eventData} />)}
+			<EventCrewTable crew={myCrew} eventData={eventData} phaseIndex={phaseIndex} buffConfig={buffConfig} />
+			<EventProspects crew={allBonusCrew} prospects={prospects} setProspects={setProspects} />
+			{eventData.content_types[phaseIndex] == 'shuttles' && (<EventShuttlers dbid={dbid} crew={myCrew} eventData={eventData} />)}
 		</React.Fragment>
 	);
 
@@ -156,22 +189,28 @@ const EventPicker = (props: EventPickerProps) => {
 		if (activePhase.content_type == 'shuttles') {
 			activePhase.shuttles.forEach((shuttle: any) => {
 				for (let symbol in shuttle.crew_bonuses) {
-					result.bonus.push(symbol);
-					if (shuttle.crew_bonuses[symbol] == 3) result.featured.push(symbol);
+					if (result.bonus.indexOf(symbol) < 0) {
+						result.bonus.push(symbol);
+						if (shuttle.crew_bonuses[symbol] == 3) result.featured.push(symbol);
+					}
 				}
 			});
 		}
 		else if (activePhase.content_type == 'gather') {
 			for (let symbol in activePhase.crew_bonuses) {
-				result.bonus.push(symbol);
-				if (activePhase.crew_bonuses[symbol] == 10) result.featured.push(symbol);
+				if (result.bonus.indexOf(symbol) < 0) {
+					result.bonus.push(symbol);
+					if (activePhase.crew_bonuses[symbol] == 10) result.featured.push(symbol);
+				}
 			}
 		}
 		else if (activePhase.content_type == 'skirmish' && activePhase.bonus_crew) {
 			for (let i = 0; i < activePhase.bonus_crew.length; i++) {
 				let symbol = activePhase.bonus_crew[i];
-				result.bonus.push(symbol);
-				result.featured.push(symbol);
+				if (result.bonus.indexOf(symbol) < 0) {
+					result.bonus.push(symbol);
+					result.featured.push(symbol);
+				}
 			}
 			// Skirmish also uses activePhase.bonus_traits to identify smaller bonus event crew
 		}
@@ -197,9 +236,17 @@ const EventCrewTable = (props: EventCrewTableProps) => {
 
 	const phaseType = phaseIndex < eventData.content_types.length ? eventData.content_types[phaseIndex] : eventData.content_types[0];
 
-	const bonusCrew = JSON.parse(JSON.stringify(props.crew));
-	if (applyBonus || showPotential) {
-		bonusCrew.forEach(crew => {
+	let bestCombos = {};
+
+	let myCrew = JSON.parse(JSON.stringify(props.crew));
+
+	// Filter crew by bonus, frozen here instead of searchabletable callback so matrix can use filtered crew list
+	if (showBonus) myCrew = myCrew.filter((c) => eventData.bonus.indexOf(c.symbol) >= 0);
+	if (!showFrozen) myCrew = myCrew.filter((c) => c.immortal == 0);
+
+	myCrew.forEach(crew => {
+		// First adjust skill scores as necessary
+		if (applyBonus || showPotential) {
 			crew.bonus = 1;
 			if (applyBonus && eventData.featured.indexOf(crew.symbol) >= 0) {
 				if (phaseType == 'gather') crew.bonus = 10;
@@ -223,8 +270,52 @@ const EventCrewTable = (props: EventCrewTableProps) => {
 					}
 				});
 			}
-		});
-	}
+		}
+		// Then calculate skill combination scores
+		let combos = [];
+		let bestCombo = { score: 0 };
+		let bestSkill = { score: 0 };
+		for (let first = 0; first < CONFIG.SKILLS_SHORT.length; first++) {
+			let firstSkill = CONFIG.SKILLS_SHORT[first];
+			if (crew[firstSkill.name].core > 0) {
+				let combo = {
+					score: crew[firstSkill.name].core,
+					skillA: firstSkill.name,
+					skillB: ''
+				};
+				combos.push(combo);
+				if (combo.score > bestCombo.score) bestCombo = combo;
+				if (combo.score > bestSkill.score) bestSkill = { score: combo.score, skill: combo.skillA };
+				if (!bestCombos[firstSkill.name] || combo.score > bestCombos[firstSkill.name].score)
+					bestCombos[firstSkill.name] = { id: crew.id, score: combo.score };
+				for (let second = first+1; second < CONFIG.SKILLS_SHORT.length; second++) {
+					let secondSkill = CONFIG.SKILLS_SHORT[second];
+					if (crew[secondSkill.name].core > 0) {
+						combo = {
+							score: crew[firstSkill.name].core+(crew[secondSkill.name].core/4),
+							skillA: firstSkill.name,
+							skillB: secondSkill.name
+						}
+						if (crew[secondSkill.name].core > crew[firstSkill.name].core) {
+							combo = {
+								score: crew[secondSkill.name].core+(crew[firstSkill.name].core/4),
+								skillA: secondSkill.name,
+								skillB: firstSkill.name
+							}
+						}
+						combos.push(combo);
+						if (combo.score > bestCombo.score) bestCombo = combo;
+						let comboId = firstSkill.name+secondSkill.name;
+						if (!bestCombos[comboId] || combo.score > bestCombos[comboId].score)
+							bestCombos[comboId] = { id: crew.id, score: combo.score };
+					}
+				}
+			}
+		}
+		//crew.combos = combos;	// Not used now, but can uncomment if needed later
+		crew.bestCombo = bestCombo;
+		crew.bestSkill = bestSkill;
+	});
 
 	return (
 		<React.Fragment>
@@ -259,12 +350,13 @@ const EventCrewTable = (props: EventCrewTableProps) => {
 			</div>
 			<SearchableTable
 				id={"eventplanner"}
-				data={bonusCrew}
+				data={myCrew}
 				config={tableConfig}
 				renderTableRow={(crew, idx) => renderTableRow(crew, idx)}
 				filterRow={(crew, filters, filterType) => showThisCrew(crew, filters, filterType)}
 				showFilterOptions="true"
 			/>
+			{phaseType != "skirmish" && (<EventCrewMatrix crew={myCrew} bestCombos={bestCombos} />)}
 		</React.Fragment>
 	);
 
@@ -289,18 +381,24 @@ const EventCrewTable = (props: EventCrewTableProps) => {
 						<div style={{ gridArea: 'description' }}>{descriptionLabel(crew)}</div>
 					</div>
 				</Table.Cell>
-				<Table.Cell>
-					<Rating icon='star' rating={crew.rarity} maxRating={crew.max_rarity} size="large" disabled />
-				</Table.Cell>
 				<Table.Cell textAlign='center'>
 					{crew.bonus > 1 ? `x${crew.bonus}` : ''}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					<b>{Math.floor(crew.bestSkill.score)}</b>
+					<br /><img alt="Skill" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${crew.bestSkill.skill}.png`} style={{ height: '1em' }} />
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					<b>{Math.floor(crew.bestCombo.score)}</b>
+					<br /><img alt="Skill" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${crew.bestCombo.skillA}.png`} style={{ height: '1em' }} />
+					{crew.bestCombo.skillB != '' && (<span>+<img alt="Skill" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${crew.bestCombo.skillB}.png`} style={{ height: '1em' }} /></span>)}
 				</Table.Cell>
 				{CONFIG.SKILLS_SHORT.map(skill =>
 					crew.base_skills[skill.name] ? (
 						<Table.Cell key={skill.name} textAlign='center'>
 							<b>{crew[skill.name].core}</b>
 							<br />
-							+({crew[skill.name].min}-{crew[skill.name].max})
+							<small>+({crew[skill.name].min}-{crew[skill.name].max})</small>
 						</Table.Cell>
 					) : (
 						<Table.Cell key={skill.name} />
@@ -311,43 +409,159 @@ const EventCrewTable = (props: EventCrewTableProps) => {
 	}
 
 	function descriptionLabel(crew: any): JSX.Element {
-		if (crew.immortal) {
-			return (
-				<div>
-					<Icon name="snowflake" /> <span>{crew.immortal} frozen</span>
-				</div>
-			);
-		} else {
-			return (
+		return (
+			<div>
+				<div><Rating icon='star' rating={crew.rarity} maxRating={crew.max_rarity} size="large" disabled /></div>
 				<div>
 					{crew.favorite && <Icon name="heart" />}
-					<span>Level {crew.level}</span>
+					{crew.immortal > 0 && <Icon name="snowflake" />}
+					{crew.prospect && <Icon name="add user" />}
+					<span>{crew.immortal ? (`${crew.immortal} frozen`) : (`Level ${crew.level}`)}</span>
 				</div>
-			);
-		}
+			</div>
+		);
 	}
 
 	function showThisCrew(crew: any, filters: [], filterType: string): boolean {
-		if (showBonus && props.eventData.bonus.indexOf(crew.symbol) == -1) {
-			return false;
-		}
-
-		if (!showFrozen && crew.immortal > 0) {
-			return false;
-		}
-
+		// Bonus, frozen crew filtering now handled before rendering entire table instead of each row
 		return crewMatchesSearchFilter(crew, filters, filterType);
 	}
+};
 
-	function applySkillBuff(buffConfig: any, skill: string, base_skill: any): { core: number, min: number, max: number } {
-		const getMultiplier = (skill: string, stat: string) => {
-			return buffConfig[`${skill}_${stat}`].multiplier + buffConfig[`${skill}_${stat}`].percent_increase;
+type EventCrewMatrixProps = {
+	crew: any[];
+	bestCombos: any;
+};
+
+const EventCrewMatrix = (props: EventCrewMatrixProps) => {
+	const {crew, bestCombos} = props;
+
+	return (
+		<React.Fragment>
+			<Header as='h4'>Skill Combo Matrix</Header>
+			<p>This table shows your best crew for each possible skill combination. Use this table to identify your best crew for this event and the best candidates to share in a faction event if you are a squad leader.</p>
+			<Table definition celled striped collapsing unstackable compact="very">
+				<Table.Header>
+					<Table.Row>
+						<Table.HeaderCell />
+						{CONFIG.SKILLS_SHORT.map((skill, cellId) => (
+							<Table.HeaderCell key={cellId} textAlign='center'>
+								<img alt={`${skill.name}`} src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${skill.name}.png`} style={{ height: '1.1em' }} />
+							</Table.HeaderCell>
+						))}
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{CONFIG.SKILLS_SHORT.map((skillA, rowId) => (
+						<Table.Row key={rowId}>
+							<Table.Cell width={1} textAlign='center'><img alt={`${skillA.name}`} src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${skillA.name}.png`} style={{ height: '1.1em' }} /></Table.Cell>
+							{CONFIG.SKILLS_SHORT.map((skillB, cellId) => renderCell(skillA.name, skillB.name))}
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table>
+		</React.Fragment>
+	);
+
+	function renderCell(skillA: string, skillB: string) : JSX.Element {
+		let key = skillA+skillB;
+		let bestCombo = bestCombos[skillA] ?? {score: 0};
+		if (bestCombos[skillB] && bestCombos[skillB].score > bestCombo.score) {
+			bestCombo = bestCombos[skillB];
+		}
+		if (bestCombos[skillA] && bestCombos[skillB]) {
+			if (bestCombos[skillA+skillB] && bestCombos[skillA+skillB].score > bestCombo.score) bestCombo = bestCombos[skillA+skillB];
+			if (bestCombos[skillB+skillA] && bestCombos[skillB+skillA].score > bestCombo.score) bestCombo = bestCombos[skillB+skillA];
+		}
+		if (bestCombo.score > 0) {
+			let bestCrew = crew.find(c => c.id == bestCombo.id);
+			let icon = (<></>);
+			if (bestCrew.immortal) icon = (<Icon name='snowflake' />);
+			if (bestCrew.prospect) icon = (<Icon name='add user' />);
+			return (
+				<Table.Cell key={key} textAlign='center'>
+					<img width={36} src={`${process.env.GATSBY_ASSETS_URL}${bestCrew.imageUrlPortrait}`} /><br/>{icon} {bestCrew.name} <small>({Math.floor(bestCombo.score)})</small>
+				</Table.Cell>
+			);
+		}
+		return (
+			<Table.Cell key={key} textAlign='center'>-</Table.Cell>
+		);
+	}
+};
+
+type EventProspectsProps = {
+	crew: any[];
+	prospects: any[];
+	setProspects: (prospects: any[]) => void;
+};
+
+const EventProspects = (props: EventProspectsProps) => {
+	const {crew, prospects, setProspects} = props;
+
+	const [selection, setSelection] = React.useState('');
+
+	const crewList = crew.map((c) => (
+		{
+			key: c.symbol,
+			value: c.symbol,
+			image: { avatar: true, src: `${process.env.GATSBY_ASSETS_URL}${c.imageUrlPortrait}` },
+			text: c.name
+		}
+	));
+
+	return (
+		<React.Fragment>
+			<Header as='h4'>Prospective Crew</Header>
+			<p>Add prospective crew (or shared crew) to see how they fit into your existing roster for this event.</p>
+			<Dropdown search selection clearable
+				placeholder='Select Crew'
+				options={crewList}
+				value={selection}
+				onChange={(e, { value }) => setSelection(value)}
+			/>
+			<Button compact icon='add user' color='green' content='Add Crew' onClick={() => { addProspect(); }} style={{ marginLeft: '1em' }} />
+			<Table celled striped collapsing unstackable compact="very">
+				<Table.Body>
+					{prospects.map((p, prospectNum) => (
+						<Table.Row key={prospectNum}>
+							<Table.Cell><img width={24} src={`${process.env.GATSBY_ASSETS_URL}${p.imageUrlPortrait}`} /></Table.Cell>
+							<Table.Cell>{p.name}</Table.Cell>
+							<Table.Cell><Rating icon='star' rating={p.rarity} maxRating={p.max_rarity} size="large" onRate={(e, {rating, maxRating}) => { fuseProspect(prospectNum, rating); }} /></Table.Cell>
+							<Table.Cell><Button compact icon='trash' color='red' onClick={() => deleteProspect(prospectNum)} /></Table.Cell>
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table>
+		</React.Fragment>
+	);
+
+	function addProspect(): void {
+		if (selection == '') return;
+		let valid = crew.find((c) => c.symbol == selection);
+		if (valid) {
+			let prospect = {
+				symbol: valid.symbol,
+				name: valid.name,
+				imageUrlPortrait: valid.imageUrlPortrait,
+				rarity: valid.max_rarity,
+				max_rarity: valid.max_rarity
+			};
+			prospects.push(prospect);
+			setProspects([...prospects]);
 		};
-		return {
-			core: Math.round(base_skill.core*getMultiplier(skill, 'core')),
-			min: Math.round(base_skill.range_min*getMultiplier(skill, 'range_min')),
-			max: Math.round(base_skill.range_max*getMultiplier(skill, 'range_max'))
-		};
+		setSelection('');
+	}
+
+	function fuseProspect(prospectNum: number, rarity: number): void {
+		if (rarity == 0) return;
+		prospects[prospectNum].rarity = rarity;
+		setProspects([...prospects]);
+	}
+
+	function deleteProspect(prospectNum: number): void {
+		prospects.splice(prospectNum, 1);
+		setProspects([...prospects]);
 	}
 };
 
@@ -391,7 +605,7 @@ const EventShuttlers = (props: EventShuttlersProps) => {
 	const [crewScores, setCrewScores] = React.useState([]);
 	const [shuttleScores, setShuttleScores] = React.useState(new Array(shuttlers.shuttles.length));
 
-	const [considerActive, setConsiderActive] = useStateWithStorage('eventplanner/considerActive', false);
+	const [considerActive, setConsiderActive] = useStateWithStorage('eventplanner/considerActive', true);
 	const [considerVoyage, setConsiderVoyage] = useStateWithStorage('eventplanner/considerVoyage', false);
 	const [considerFrozen, setConsiderFrozen] = useStateWithStorage('eventplanner/considerFrozen', false);
 	const [saveSetups, setSaveSetups] = useStateWithStorage(props.dbid+'/eventplanner/saveSetups', false, { rememberForever: true });
@@ -406,7 +620,7 @@ const EventShuttlers = (props: EventShuttlersProps) => {
 
 	React.useEffect(() => {
 		updateCrewScores(true);
-	}, [considerActive, considerVoyage, considerFrozen]);
+	}, [props.crew, considerActive, considerVoyage, considerFrozen]);
 
 	// Shuttle setups and assignments are saved in local storage,
 	//	so we must check whether to clear them on session close
@@ -436,15 +650,7 @@ const EventShuttlers = (props: EventShuttlersProps) => {
 					{shuttlers.shuttles.map((shuttle, shuttleNum) => (
 						<Table.Row key={shuttleNum}>
 							<Table.Cell>
-								<Input
-									placeholder="Mission name..."
-									value={shuttle.name}
-									onChange={(e, { value }) => onRenameShuttle(shuttleNum, value)}>
-										<input />
-										<Button icon onClick={() => onRenameShuttle(shuttleNum, '')} >
-											<Icon name='delete' />
-										</Button>
-								</Input>
+								<EventShuttlersRenamer shuttleNum={shuttleNum} shuttleName={shuttle.name} updateCallback={updateShuttleName} />
 								<Button icon color='red' onClick={() => deleteShuttle(shuttleNum)}><Icon name='trash' /></Button>
 								{shuttleScores[shuttleNum] ? <div>{Math.floor(shuttleScores[shuttleNum].chance*100)}% Chance</div> : <></>}
 							</Table.Cell>
@@ -455,7 +661,7 @@ const EventShuttlers = (props: EventShuttlersProps) => {
 											<Table.Row key={`${shuttleNum}_${seatNum}`}>
 												<Table.Cell><EventShuttlersSeat shuttleNum={shuttleNum} seatNum={seatNum} seat={seat} updateCallback={updateShuttleSeat} /></Table.Cell>
 												<Table.Cell><EventShuttlersCrewPicker shuttleNum={shuttleNum} seatNum={seatNum} seat={seat} skillsets={skillsets} assigned={assigned} updateCallback={updateAssignment} /></Table.Cell>
-												<Table.Cell><Button icon color='red' onClick={() => deleteShuttleSeat(shuttleNum, seatNum)}><Icon name='trash' /></Button></Table.Cell>
+												<Table.Cell><Button compact icon='trash' color='red' onClick={() => deleteShuttleSeat(shuttleNum, seatNum)} /></Table.Cell>
 											</Table.Row>
 										))}
 									</Table.Body>
@@ -505,7 +711,7 @@ const EventShuttlers = (props: EventShuttlersProps) => {
 		</React.Fragment>
 	);
 
-	function onRenameShuttle(shuttleNum: number, shuttleName: string): void {
+	function updateShuttleName(shuttleNum: number, shuttleName: string): void {
 		shuttlers.shuttles[shuttleNum].name = shuttleName;
 		updateShuttlers();
 	}
@@ -722,6 +928,39 @@ const EventShuttlers = (props: EventShuttlersProps) => {
 	}
 };
 
+type EventShuttlersRenamerProps = {
+	shuttleNum: number;
+	shuttleName: string;
+	updateCallback: (shuttleNum: number, shuttleName: string) => void;
+};
+
+const EventShuttlersRenamer = (props: EventShuttlersRenamerProps) => {
+	const [shuttleName, setShuttleName] = React.useState(props.shuttleName);
+
+	return (
+		<Input
+			placeholder="Mission name..."
+			value={shuttleName}
+			onChange={(e, { value }) => onRenameShuttle(value)}>
+				<input />
+				<Button icon onClick={() => onRenameShuttle('')} >
+					<Icon name='delete' />
+				</Button>
+		</Input>
+	);
+
+	// Wait for user to finish typing so that parent UI doesn't re-render on every keystroke
+	let timeoutId;
+	function onRenameShuttle(shuttleName: string) : void {
+		setShuttleName(shuttleName);
+		if (timeoutId) clearTimeout(timeoutId);
+		timeoutId = setTimeout(() => {
+			const {shuttleNum, updateCallback} = props;
+			updateCallback(shuttleNum, shuttleName);
+		}, 500);
+	}
+};
+
 type EventShuttlersSeatProps = {
 	shuttleNum: number;
 	seatNum: number;
@@ -807,6 +1046,17 @@ const EventShuttlersCrewPicker = (props: EventShuttlersCrewPickerProps) => {
 			onChange={(e, { value }) => updateCallback(shuttleNum, seatNum, scores.find(score => score.id == value))}
 		/>
 	);
+}
+
+function applySkillBuff(buffConfig: any, skill: string, base_skill: any): { core: number, min: number, max: number } {
+	const getMultiplier = (skill: string, stat: string) => {
+		return buffConfig[`${skill}_${stat}`].multiplier + buffConfig[`${skill}_${stat}`].percent_increase;
+	};
+	return {
+		core: Math.round(base_skill.core*getMultiplier(skill, 'core')),
+		min: Math.round(base_skill.range_min*getMultiplier(skill, 'range_min')),
+		max: Math.round(base_skill.range_max*getMultiplier(skill, 'range_max'))
+	};
 }
 
 export default EventPlanner;

--- a/src/components/eventplanner.tsx
+++ b/src/components/eventplanner.tsx
@@ -13,15 +13,15 @@ import { calculateBuffConfig } from '../utils/voyageutils';
 
 const tableConfig: ITableConfigRow[] = [
 	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'max_rarity', 'level'] },
-	{ width: 1, column: 'bonus', title: 'Bonus' },
-	{ width: 1, column: 'bestSkill.score', title: 'Best' },
-	{ width: 1, column: 'bestPair.score', title: 'Pair' },
-	{ width: 1, column: 'command_skill.core', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'science_skill.core', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'security_skill.core', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'engineering_skill.core', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'diplomacy_skill.core', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'medicine_skill.core', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} /> }
+	{ width: 1, column: 'bonus', title: 'Bonus', reverse: true },
+	{ width: 1, column: 'bestSkill.score', title: 'Best', reverse: true },
+	{ width: 1, column: 'bestPair.score', title: 'Pair', reverse: true },
+	{ width: 1, column: 'command_skill.core', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'science_skill.core', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'security_skill.core', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'engineering_skill.core', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'diplomacy_skill.core', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'medicine_skill.core', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} />, reverse: true }
 ];
 
 type EventPlannerProps = {

--- a/src/pages/playertools.tsx
+++ b/src/pages/playertools.tsx
@@ -197,7 +197,7 @@ const PlayerToolsPanes = (props: PlayerToolsPanesProps) => {
 		},
 		{
 			menuItem: 'Event Planner',
-			render: () => <EventPlanner playerData={playerData} eventData={eventData} activeCrew={activeCrew} />
+			render: () => <EventPlanner playerData={playerData} eventData={eventData} activeCrew={activeCrew} allCrew={allCrew} />
 		},
 		{
 			menuItem: 'Crew',

--- a/src/utils/crewutils.ts
+++ b/src/utils/crewutils.ts
@@ -311,7 +311,9 @@ export function prepareProfileData(allcrew, playerData, lastModified) {
 	// Merge with player crew
 	let ownedCrew = [];
 	let unOwnedCrew = [];
-	for (let crew of allcrew) {
+	for (let oricrew of allcrew) {
+		// Create a copy of crew instead of directly modifying the source (allcrew)
+		let crew = JSON.parse(JSON.stringify(oricrew));
 		crew.rarity = crew.max_rarity;
 		crew.level = 100;
 		crew.have = false;


### PR DESCRIPTION
The event planner crew table now includes 2 columns that show each crew's single best skill and best skill pair. Both columns are sortable by score.

New feature: Skill Matrix. Beneath the event crew table is a new table that shows your best crew for each possible skill combination.

New feature: Prospective Crew. You can now see how prospective crew fit into your existing roster, specifically how they compare to your other event crew in the crew table and matrix. This can also be used to consider shared crew in the shuttle helper. Note that prospective crew will use your buffs (not your squad leader's) and they will not be saved across sessions. Resolves #253.

Renaming shuttles in the shuttle helper is more responsive now.

The "Consider crew on active shuttles" option is now checked by default. This will more properly show recommendations from a previous session.

Changed the prepareProfileData util to work on a copy of allcrew rather than modify it directly. Otherwise it creates potential inconsistencies with the crew data in session.