### PR TITLE
Link ranks on crew pages to sorted table

### DIFF
--- a/src/components/commoncrewdata.tsx
+++ b/src/components/commoncrewdata.tsx
@@ -332,9 +332,11 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 			: crew.ranks[rank].rank;
 
 		// Need to filter by skills first before sorting by voyage triplet
-		const tripletFilter = crew.ranks.voyTriplet.name.split('/')
-								.map(s => 'skill:'+s.trim())
-								.reduce((prev, curr) => prev+' '+curr);
+		const tripletFilter = crew.ranks.voyTriplet
+								? crew.ranks.voyTriplet.name.split('/')
+									.map(s => 'skill:'+s.trim())
+									.reduce((prev, curr) => prev+' '+curr)
+								: '';
 
 		for (let rank in crew.ranks) {
 			if (rank.startsWith('V_')) {
@@ -398,7 +400,7 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 }
 
 const rankLinker = (roster: any, rank: number, symbol: string, column: string, direction: string, searchFilter: string) => {
-	if (!roster) return (<>{rank}</>);
+	if (roster) return (<>{rank}</>);
 	const linkState = {
 		searchFilter: searchFilter ?? '',
 		column: column,

--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -5,6 +5,7 @@ import { navigate } from 'gatsby';
 import { SearchableTable, ITableConfigRow } from '../components/searchabletable';
 
 import CONFIG from '../components/CONFIG';
+import CABExplanation from '../components/cabexplanation';
 
 import { crewMatchesSearchFilter } from '../utils/crewsearch';
 import { formatTierLabel } from '../utils/crewutils';
@@ -14,15 +15,15 @@ const rarityLabels = ['Common', 'Uncommon', 'Rare', 'Super Rare', 'Legendary'];
 
 const tableConfig: ITableConfigRow[] = [
 	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
-	{ width: 1, column: 'max_rarity', title: 'Rarity' },
-	{ width: 1, column: 'cab_ov', title: 'CAB' },
+	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true },
+	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true },
 	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
-	{ width: 1, column: 'command_skill.core', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ width: '1em' }} />  },
-	{ width: 1, column: 'science_skill.core', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'security_skill.core', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'engineering_skill.core', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'diplomacy_skill.core', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'medicine_skill.core', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ width: '1em' }} /> }
+	{ width: 1, column: 'command_skill.core', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'science_skill.core', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'security_skill.core', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'engineering_skill.core', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'diplomacy_skill.core', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'medicine_skill.core', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} />, reverse: true }
 ];
 
 type ProfileCrewProps = {
@@ -78,7 +79,7 @@ const ProfileCrew = (props: ProfileCrewProps) => {
 				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>{crew.cab_ov}</b><br />
-					<small style={{ fontSize: '70%' }}>{rarityLabels[parseInt(crew.max_rarity)-1]} #{crew.cab_ov_rank}</small>
+					<small>{rarityLabels[parseInt(crew.max_rarity)-1]} #{crew.cab_ov_rank}</small>
 				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>#{crew.ranks.voyRank}</b><br />
@@ -107,14 +108,21 @@ const ProfileCrew = (props: ProfileCrewProps) => {
 				</div>
 			);
 		} else {
+			const counts = [
+				{ name: 'event', count: crew.events },
+				{ name: 'collection', count: crew.collections.length }
+			];
+			const formattedCounts = counts.map((count, idx) => (
+				<span key={idx} style={{ whiteSpace: 'nowrap' }}>
+					{count.count} {count.name}{count.count != 1 ? 's' : ''}{idx < counts.length-1 ? ',' : ''}
+				</span>
+			)).reduce((prev, curr) => [prev, ' ', curr]);
+
 			return (
 				<div>
 					{crew.favorite && <Icon name="heart" />}
 					<span>Level {crew.level}, </span>
-					{crew.bigbook_tier && crew.bigbook_tier > 0 && <span>Tier {formatTierLabel(crew.bigbook_tier)} (Legacy), </span>}
-					<br />
-					<span>{crew.events} events, </span>
-					<span>{crew.collections.length} collections</span>
+					{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)} (Legacy), </>}{formattedCounts}
 				</div>
 			);
 		}

--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -15,8 +15,8 @@ const rarityLabels = ['Common', 'Uncommon', 'Rare', 'Super Rare', 'Legendary'];
 
 const tableConfig: ITableConfigRow[] = [
 	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
-	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true },
-	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true },
+	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true, tiebreakers: ['rarity'] },
+	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
 	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
 	{ width: 1, column: 'command_skill.core', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
 	{ width: 1, column: 'science_skill.core', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} />, reverse: true },

--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -65,7 +65,9 @@ export const SearchableTable = (props: SearchableTableProps) => {
 
 	// We only sort here to store requested column and direction in state
 	//	Actual sorting of full dataset will occur on next render before filtering and pagination
-	function handleSort(clickedColumn, pseudocolumns) {
+	function handleSort(clickedColumn, pseudocolumns, reverse) {
+		if (!clickedColumn) return;
+
 		const sortConfig: IConfigSortData = {
 			field: clickedColumn,
 			direction: direction
@@ -81,7 +83,7 @@ export const SearchableTable = (props: SearchableTableProps) => {
 		} else {
 			if(clickedColumn !== column) {
 				// sort rarity and skills descending first by default
-				sortConfig.direction = 'ascending';
+				sortConfig.direction = reverse ? 'ascending' : 'descending';
 			}
 		}
 
@@ -105,7 +107,7 @@ export const SearchableTable = (props: SearchableTableProps) => {
 						key={idx}
 						width={cell.width as any}
 						sorted={((cell.pseudocolumns && cell.pseudocolumns.includes(column)) || (column === cell.column)) ? direction : null}
-						onClick={() => handleSort(cell.column, cell.pseudocolumns)}
+						onClick={() => handleSort(cell.column, cell.pseudocolumns, cell.reverse)}
 						textAlign={cell.width === 1 ? 'center' : 'left'}
 					>
 						{cell.title}{cell.pseudocolumns?.includes(column) && <><br/><small>{column}</small></>}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,15 +23,15 @@ type IndexPageState = {
 
 const tableConfig: ITableConfigRow[] = [
 	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
-	{ width: 1, column: 'max_rarity', title: 'Rarity' },
-	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span> },
+	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true },
+	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true },
 	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
-	{ width: 1, column: 'command_skill', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'science_skill', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'security_skill', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'engineering_skill', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'diplomacy_skill', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} /> },
-	{ width: 1, column: 'medicine_skill', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} /> }
+	{ width: 1, column: 'command_skill', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'science_skill', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'security_skill', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'engineering_skill', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'diplomacy_skill', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
+	{ width: 1, column: 'medicine_skill', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} />, reverse: true }
 ];
 
 class IndexPage extends Component<IndexPageProps, IndexPageState> {
@@ -107,7 +107,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}>{crew.name}</span>
 						</div>
 						<div style={{ gridArea: 'description' }}>
-							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)}, </>}{formattedCounts}
+							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)} (Legacy), </>}{formattedCounts}
 						</div>
 					</div>
 				</Table.Cell>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,8 @@ type IndexPageProps = {};
 
 type IndexPageState = {
 	botcrew: any[];
-	searchFilterType: string;
+	initOptions: any;
+	highlights: string[];
 };
 
 const tableConfig: ITableConfigRow[] = [
@@ -25,16 +26,16 @@ const tableConfig: ITableConfigRow[] = [
 	{ width: 1, column: 'max_rarity', title: 'Rarity' },
 	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span> },
 	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
-	{ width: 1, column: 'command_skill', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'science_skill', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'security_skill', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'engineering_skill', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'diplomacy_skill', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ width: '1em' }} /> },
-	{ width: 1, column: 'medicine_skill', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ width: '1em' }} /> }
+	{ width: 1, column: 'command_skill', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} /> },
+	{ width: 1, column: 'science_skill', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} /> },
+	{ width: 1, column: 'security_skill', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} /> },
+	{ width: 1, column: 'engineering_skill', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} /> },
+	{ width: 1, column: 'diplomacy_skill', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} /> },
+	{ width: 1, column: 'medicine_skill', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} /> }
 ];
 
 class IndexPage extends Component<IndexPageProps, IndexPageState> {
-	state = { botcrew: [], searchFilterType: 'Any match' };
+	state = { botcrew: [], initOptions: false, highlights: [] };
 
 	async componentDidMount() {
 		let response = await fetch('/structured/crew.json');
@@ -47,12 +48,50 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 			});
 		});
 
-		this.setState({ botcrew });
+		// Check for custom initial table options from URL or <Link state>
+		let initOptions = false, highlights = [];
+		const OPTIONS = ['searchFilter', 'filterType', 'column', 'direction', 'paginationRows', 'paginationPage'];
+
+		// Always use URL search parameter if found
+		//	TODO: Allow URL parameters for all options (with validation) so we can permalink search results
+		let urlParams = new URLSearchParams(this.props.location.search);
+		if (urlParams.has('search')) {
+			initOptions = { searchFilter: urlParams.get('search') };
+		}
+		// Otherwise check <Link state>
+		else if (this.props.location.state) {
+			const linkState = this.props.location.state;
+			OPTIONS.forEach((option) => {
+				if (linkState[option]) {
+					if (!initOptions) initOptions = {};
+					initOptions[option] = linkState[option];
+				}
+			});
+			if (linkState.highlights) highlights = linkState.highlights;
+			// Clear history state now so that new stored values aren't overriden by outdated parameters
+			window.history.replaceState(null, '');
+		}
+
+		this.setState({ botcrew, initOptions, highlights });
 	}
 
 	renderTableRow(crew: any): JSX.Element {
+		const highlighted = {
+			positive: this.state.highlights.indexOf(crew.symbol) >= 0
+		};
+
+		const counts = [
+			{ name: 'event', count: crew.events },
+			{ name: 'collection', count: crew.collections.length }
+		];
+		const formattedCounts = counts.map((count, idx) => (
+			<span key={idx} style={{ whiteSpace: 'nowrap' }}>
+				{count.count} {count.name}{count.count != 1 ? 's' : ''}{idx < counts.length-1 ? ',' : ''}
+			</span>
+		)).reduce((prev, curr) => [prev, ' ', curr]);
+
 		return (
-			<Table.Row key={crew.symbol} style={{ cursor: 'zoom-in' }} onClick={() => navigate(`/crew/${crew.symbol}/`)}>
+			<Table.Row key={crew.symbol} style={{ cursor: 'zoom-in' }} onClick={() => navigate(`/crew/${crew.symbol}/`)} {...highlighted}>
 				<Table.Cell>
 					<div
 						style={{
@@ -68,7 +107,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}>{crew.name}</span>
 						</div>
 						<div style={{ gridArea: 'description' }}>
-							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)}, </>}{crew.events} events, {crew.collections.length} collections
+							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)}, </>}{formattedCounts}
 						</div>
 					</div>
 				</Table.Cell>
@@ -77,7 +116,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>{crew.cab_ov}</b><br />
-					<small style={{ fontSize: '70%' }}>{rarityLabels[parseInt(crew.max_rarity)-1]} #{crew.cab_ov_rank}</small>
+					<small>{rarityLabels[parseInt(crew.max_rarity)-1]} #{crew.cab_ov_rank}</small>
 				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>#{crew.ranks.voyRank}</b><br />
@@ -100,7 +139,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 	}
 
 	render() {
-		const { botcrew } = this.state;
+		const { botcrew, initOptions } = this.state;
 		if (!botcrew || botcrew.length === 0) {
 			return (
 				<Layout>
@@ -119,6 +158,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 					config={tableConfig}
 					renderTableRow={crew => this.renderTableRow(crew)}
 					filterRow={(crew, filter, filterType) => crewMatchesSearchFilter(crew, filter, filterType)}
+					initOptions={initOptions}
 					showFilterOptions={true}
 				/>
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,9 +22,9 @@ type IndexPageState = {
 };
 
 const tableConfig: ITableConfigRow[] = [
-	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
+	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events', 'date_added'] },
 	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true },
-	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true },
+	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
 	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
 	{ width: 1, column: 'command_skill', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
 	{ width: 1, column: 'science_skill', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} />, reverse: true },

--- a/src/utils/datasort.ts
+++ b/src/utils/datasort.ts
@@ -25,7 +25,7 @@ export function sortDataBy(data: any[], config: IConfigSortData): IResultSortDat
 	if(!keepSortOptions) {
 		direction = setDirection(direction);
 	}
-	
+
 	if(config.secondary) {
 		config.secondary.direction = config.secondary.direction === null ? setDirection(null) : config.secondary.direction;
 		config.secondary.direction = keepSortOptions === true ? config.secondary.direction : setDirection(config.secondary.direction);
@@ -44,11 +44,11 @@ export function sortDataBy(data: any[], config: IConfigSortData): IResultSortDat
 			getValueFromPath(config.secondary.direction === 'ascending' ? b : a, config.secondary.field)
 		));
 	}
-	
+
 	if(direction === 'descending') {
 		result.reverse();
 	}
-	
+
 	return {
 		field,
 		direction,
@@ -75,6 +75,8 @@ function compare(a, b) {
 	if(!isNaN(a) && !isNaN(b)) {
 		return a - b;
 	}
+	if (isNaN(a) && !isNaN(b)) return 1;
+	if (!isNaN(a) && isNaN(b)) return -1;
 	return (a > b ? 1 : b > a ? -1 : 0);
 }
 

--- a/src/utils/datasort.ts
+++ b/src/utils/datasort.ts
@@ -5,6 +5,7 @@ export interface IConfigSortData {
 		field: string;
 		direction: 'descending' | 'ascending' | null;
 	};
+	subsort?: any[]; // rules for tiebreakers e.g. { field, direction }
 	rotateFields?: any[];
 	keepSortOptions?: boolean; // if set to true, don't advance direction or rotateFields
 }
@@ -23,31 +24,36 @@ export function sortDataBy(data: any[], config: IConfigSortData): IResultSortDat
 		field = getNextFieldInRotation(field, config.rotateFields);
 	}
 	if(!keepSortOptions) {
-		direction = setDirection(direction);
+		direction = toggleDirection(direction);
 	}
 
+	config.subsort = config.subsort ?? [];
+
+	// Convert secondary prop to subsort array; try to use subsort instead of secondary from now on
 	if(config.secondary) {
-		config.secondary.direction = config.secondary.direction === null ? setDirection(null) : config.secondary.direction;
-		config.secondary.direction = keepSortOptions === true ? config.secondary.direction : setDirection(config.secondary.direction);
+		config.secondary.direction = config.secondary.direction ?? 'ascending';
+		if (!keepSortOptions) config.secondary.direction = toggleDirection(config.secondary.direction);
+		config.subsort = [{ field: config.secondary.field, direction: config.secondary.direction }];
 	}
 
-	if(!config.secondary) {
-		result = result.sort((a, b) => compare(
+	const sortFactor = direction === 'descending' ? -1 : 1;
+	result = result.sort((a, b) => {
+		let sortValue = sortFactor*compare(
 			getValueFromPath(a, field),
 			getValueFromPath(b, field)
-		));
-	} else {
-		result = result.sort((a, b) => compareWithSecondary(
-			getValueFromPath(a, field),
-			getValueFromPath(b, field),
-			getValueFromPath(config.secondary.direction === 'ascending' ? a : b, config.secondary.field),
-			getValueFromPath(config.secondary.direction === 'ascending' ? b : a, config.secondary.field)
-		));
-	}
-
-	if(direction === 'descending') {
-		result.reverse();
-	}
+		);
+		let tiebreaker = 0;
+		while (sortValue == 0 && tiebreaker < config.subsort.length) {
+			const nextSort = config.subsort[tiebreaker];
+			const nextFactor = nextSort.direction === 'descending' ? -1 : 1;
+			sortValue = nextFactor*compare(
+				getValueFromPath(a, nextSort.field),
+				getValueFromPath(b, nextSort.field)
+			);
+			tiebreaker++;
+		}
+		return sortValue;
+	});
 
 	return {
 		field,
@@ -67,7 +73,7 @@ function getNextFieldInRotation(field, rotateFields) {
 	return newField;
 }
 
-function setDirection(direction) {
+function toggleDirection(direction) {
 	return direction === 'ascending' ? 'descending' : 'ascending';
 }
 
@@ -78,11 +84,4 @@ function compare(a, b) {
 	if (isNaN(a) && !isNaN(b)) return 1;
 	if (!isNaN(a) && isNaN(b)) return -1;
 	return (a > b ? 1 : b > a ? -1 : 0);
-}
-
-function compareWithSecondary(a, b, c, d) {
-	if(!isNaN(a) && !isNaN(b) && !isNaN(c) && !isNaN(d)) {
-		return a - b || c - d;
-	}
-	return (a > b ? 1 : b > a ? -1 : 0) || (c > d ? 1 : d > c ? -1 : 0);
 }


### PR DESCRIPTION
This adds links to most ranks shown on crew pages, which open up a properly sorted table with the crew highlighted so you can more easily see others with similar ranks.

Specifically this adds links to the 3 main ranks (CAB, Voyage, Gauntlet) on crew pages and to every rank in the "More stats" accordion. Note that when sorting is done by fields not shown on the table (e.g. gauntlet pair), there is no visual way to know what the sorting criteria currently is.

All crew tables that use searchabletable now sort with most recent crew listed first by default. This resolves #211. Searchabletable config has two new properties (`reverse` and `tiebreakers`) to customize a column's default sort order and how to handle ties when sorting. If no tiebreaker is defined, the column now tries to break ties alphabetically.

Made other small formatting changes to index and searchabletable.

Fixed datasort util to properly compare numbers with non-numbers (i.e. undefined) so that sorting works more reliably. This should also mean that we no longer have to pre-zero sortable columns before passing data to searchabletable. This is an attempt to fix #166, but there still might be some inconsistencies here.

Also fixed datasort to better handle tiebreakers (previously defined as `secondary`) and simplified the compare algorithm.

Edit: "On your roster" ranks have a different crew pool and they should link to the playertool/crew page instead of the main crew table. Because there are no dedicated player tool URLs yet, we can't do roster rank links on the behold page for the time being.