### PR TITLE
Adds prospective polestars, multiples, and more to crew retrieval

### DIFF
--- a/src/pages/playertools.tsx
+++ b/src/pages/playertools.tsx
@@ -209,7 +209,7 @@ const PlayerToolsPanes = (props: PlayerToolsPanesProps) => {
 		},
 		{
 			menuItem: 'Crew Retrieval',
-			render: () => <CrewRetrieval playerData={playerData} />
+			render: () => <CrewRetrieval playerData={playerData} allCrew={allCrew} />
 		},
 		{
 			menuItem: 'Ships',


### PR DESCRIPTION
Big update to crew retrieval player tool, a few new features plus quality of life changes.

Adds "Prospective Polestars" feature, which lets you identify needed polestars for crew you can't retrieve with your current inventory and preview retrieval options that you'd be able to perform if you acquired certain polestars. This also lists the odds of acquiring any polestar from a scan and constellations you own. Partially based on feature requests in #80, but also ties in a few other ideas at the same time. Click the "+" button (right next to the polestar filter button) to use this feature.

When viewing a crew's usable combos, you can now see if the crew can be retrieved multiple times given your current polestar inventory. If so, you can cycle through the various group of combos that will yield a desired number of retrievals. Click the combos to quickly cycle through the options.

Tweaks combo view to be limited to 4 columns, with the toggle link fixed to the rightmost column.

Adds a "Collections" column to the table, which can be sorted. When a crew's collection number is clicked, the crew's collections will be listed by name.

Now uses the `searchabletable` component for the crew table, which consolidates sorting and paging logic, and allows for filtering results by text.

Adds buttons to the polestars filter modal to quickly check/uncheck all polestars in a group (e.g. rarity, skills), resolving a few requests from #169.

Refactors `crewretrieval` as a functional component instead of class component, as we've done previously with several other player tools. The most notable benefit here is that form fields will remember their last values between page changes.

Inherits `allCrew` from the parent (`playertools`) component instead of fetching crew.json, which speeds up the initial page load. Lots of logic has been moved around to speed up the main crew retrieval form, though the prospective polestars function could probably be optimized.

Incorporates a few changes first proposed by flash82 in #140, specifically modifying dropdown options for clarification. Resolves #100. Some sorting quirks that may be present here will be resolved by #269.