### PR TITLE
Adds announcement message to index

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,6 +62,13 @@ module.exports = {
 			}
 		},
 		{
+			resolve: 'gatsby-source-filesystem',
+			options: {
+				name: 'announcements',
+				path: `${__dirname}/static/announcements/`
+			}
+		},
+		{
 			resolve: `gatsby-plugin-manifest`,
 			options: {
 				name: `Star Trek Timelines DataCore`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,6 +12,13 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 			name: `slug`,
 			value: slug
 		});
+		const parent = getNode(node.parent);
+		let source = parent.sourceInstanceName;
+		createNodeField({
+			node,
+			name: `source`,
+			value: source,
+		});
 	} else if (node.internal.type === `EpisodesJson`) {
 		createNodeField({
 			node,

--- a/static/announcements/20211011.md
+++ b/static/announcements/20211011.md
@@ -1,0 +1,8 @@
+---
+title: "What's New to DataCore"
+date: 2021-10-11T17:00:00Z
+class: "info"
+icon: "info"
+---
+- Links to all player tools have been moved to the main menu under "Player tools"
+- The crew retrieval player tool has new features: prospective polestars, multiple retrieval counts, and collection counts


### PR DESCRIPTION
This adds a quick way to show announcement messages on DataCore's front page.

Announcements are written as markdown files in the static folder with fields for customizing the header, semantic UI icon, and semantic UI class. Right now only the most recent announcement will appear and it's present for only 3 days beyond the posted date.

Some potential areas for improvement:
* adding a template so we can link an excerpted message to a page with full details (or to a page that shows all messages)
* adding the ability to dismiss announcements

Some potential things to doublecheck:
* not sure if the expiration threshold coded here will work with gatsby, but should be okay if the site is re-built on a regular basis
* similarly, there might be a more reliable way to query this with graphql