### PR TITLE
Various sort fixes

### DIFF
--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -116,7 +116,7 @@ export const SearchableTable = (props: SearchableTableProps) => {
 						onClick={() => onHeaderClick(cell)}
 						textAlign={cell.width === 1 ? 'center' : 'left'}
 					>
-						{cell.title}{cell.pseudocolumns?.includes(column) && <><br/><small>{column}</small></>}
+						{cell.title}{cell.pseudocolumns?.includes(column) && <><br/><small>{column.replace('_',' ')}</small></>}
 					</Table.HeaderCell>
 				))}
 			</Table.Row>
@@ -137,7 +137,7 @@ export const SearchableTable = (props: SearchableTableProps) => {
 		const columnConfig = props.config.find(col => col.column === column);
 		if (columnConfig && columnConfig.tiebreakers) {
 			subsort = columnConfig.tiebreakers.map(subfield => {
-				const subdirection = subfield == 'rarity' ? direction : 'ascending';
+				const subdirection = subfield.substr(subfield.length-6) === 'rarity' ? direction : 'ascending';
 				return { field: subfield, direction: subdirection };
 			});
 		}

--- a/src/utils/datasort.ts
+++ b/src/utils/datasort.ts
@@ -39,8 +39,8 @@ export function sortDataBy(data: any[], config: IConfigSortData): IResultSortDat
 	const sortFactor = direction === 'descending' ? -1 : 1;
 	result = result.sort((a, b) => {
 		let sortValue = sortFactor*compare(
-			getValueFromPath(a, field),
-			getValueFromPath(b, field)
+			field === 'bigbook_tier' ? getTier(a, direction) : getValueFromPath(a, field),
+			field === 'bigbook_tier' ? getTier(b, direction) : getValueFromPath(b, field)
 		);
 		let tiebreaker = 0;
 		while (sortValue == 0 && tiebreaker < config.subsort.length) {
@@ -62,6 +62,12 @@ export function sortDataBy(data: any[], config: IConfigSortData): IResultSortDat
 	};
 }
 
+// Hack to always move a crew without a tier rating to the back of a tier sort
+function getTier(obj, direction) {
+	if (obj.bigbook_tier > 0) return obj.bigbook_tier;
+	return direction === 'ascending' ? 100 : -1;
+}
+
 function getValueFromPath(obj, path) {
 	return path.split('.').reduce((a, b) => (a || {b: 0})[b], obj);
 }
@@ -81,7 +87,7 @@ function compare(a, b) {
 	if(!isNaN(a) && !isNaN(b)) {
 		return a - b;
 	}
-	if (isNaN(a) && !isNaN(b)) return 1;
-	if (!isNaN(a) && isNaN(b)) return -1;
+	if (isNaN(a) && !isNaN(b)) return -1;
+	if (!isNaN(a) && isNaN(b)) return 1;
 	return (a > b ? 1 : b > a ? -1 : 0);
 }


### PR DESCRIPTION
Fixes sorting by rarity on crew retrieval tool.

Fixes CAB sorting on all searchabletables so that crew without a CAB rating are moved to the back of a descending sort (and shown first on an ascending sort), which makes the ordering more predictable, i.e. treating unrated crew as if their CAB rating was 0.

Fixes big book tier sorting on all searchabletables so that crew without a tier rating are moved to the back of BOTH sorting directions. This is very hacky, but preferable because the big book's real value is on an ascending sort. Otherwise unrated crew tiers are -1 (or sometimes undefined), which would give them priority over Tier 1 crew on an ascending sort.

Replaced underscores on pseudocolumn names as shown on searchabletables.