### PR TITLE
Fix announcements details link color

### DIFF
--- a/static/styles/semantic.slate.css
+++ b/static/styles/semantic.slate.css
@@ -26531,7 +26531,7 @@ Floated Menu / Item
 
 .ui.message a {
   text-decoration: underline;
-  color: #fff;
+  color: inherit;
 }
 
 /*******************************


### PR DESCRIPTION
Resolves #305 by changing link style to inherit color from parent element. Should work more consistently than hardcoding white for all message styles on all themes.