### PR TITLE
Make comma delimited csv the default export option

### DIFF
--- a/src/utils/crewutils.ts
+++ b/src/utils/crewutils.ts
@@ -227,7 +227,7 @@ export function exportCrewFields(): ExportField[] {
 	];
 }
 
-export function exportCrew(crew, delimeter = '\t'): string {
+export function exportCrew(crew, delimeter = ','): string {
 	return simplejson2csv(crew, exportCrewFields(), delimeter);
 }
 


### PR DESCRIPTION
This was what was supposed to happen but I apparently had a brain fart and did it the wrong way round.