### PR TITLE
Fixes announcement expiration

### DIFF
--- a/src/components/announcement.tsx
+++ b/src/components/announcement.tsx
@@ -56,7 +56,7 @@ const Announcement = () => {
 			if (dateDismissed > datePosted) return (<></>);
 		}
 
-		const dateExpires = new Date();
+		const dateExpires = new Date(datePosted);
 		dateExpires.setDate(datePosted.getDate()+DAYS_TO_EXPIRE);
 		if (dateExpires < dateNow) return (<></>);
 


### PR DESCRIPTION
Fixes announcement expiration so that the expiration test properly considers the month, day, and year relative to the date posted (instead of just the current day); otherwise the expiration might reset at the start of a new month/year.