### PR TITLE
Limit fuse combos in crew retrieval

### DIFF
--- a/src/components/crewretrieval.tsx
+++ b/src/components/crewretrieval.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Table, Icon, Rating, Dropdown, Form, Button, Checkbox, Header, Modal, Grid, Message } from 'semantic-ui-react';
-import { navigate } from 'gatsby';
+import { Link } from 'gatsby';
 
 import ItemDisplay from '../components/itemdisplay';
 import { SearchableTable, ITableConfigRow } from '../components/searchabletable';
@@ -1005,7 +1005,7 @@ const CrewTable = (props: CrewTableProps) => {
 	function renderTableRow(crew: any, idx: number): JSX.Element {
 		return (
 			<Table.Row key={idx}>
-				<Table.Cell style={{ cursor: 'zoom-in' }} onClick={() => navigate(`/crew/${crew.symbol}/`)}>
+				<Table.Cell>
 					<div
 						style={{
 							display: 'grid',
@@ -1018,7 +1018,7 @@ const CrewTable = (props: CrewTableProps) => {
 							<img width={48} src={`${process.env.GATSBY_ASSETS_URL}${crew.imageUrlPortrait}`} />
 						</div>
 						<div style={{ gridArea: 'stats' }}>
-							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}>{crew.name}</span>
+							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}><Link to={`/crew/${crew.symbol}/`}>{crew.name}</Link></span>
 						</div>
 						<div style={{ gridArea: 'description' }}>{getCoolStats(crew, false, false)}</div>
 					</div>
@@ -1099,12 +1099,15 @@ const CrewTable = (props: CrewTableProps) => {
 						fuseGroups[parentId].push(parentGroup);
 					else
 						fuseGroups[parentId] = [parentGroup];
-					let childGroups = groupByFuses(combos, comboId, parentGroup);
-					for (let childId in childGroups) {
-						if (fuseGroups[childId])
-							fuseGroups[childId] = fuseGroups[childId].concat(childGroups[childId]);
-						else
-							fuseGroups[childId] = childGroups[childId];
+					// Only collect combo groups up to 5 fuses
+					if (parentGroup.length < 5) {
+						let childGroups = groupByFuses(combos, comboId, parentGroup);
+						for (let childId in childGroups) {
+							if (fuseGroups[childId])
+								fuseGroups[childId] = fuseGroups[childId].concat(childGroups[childId]);
+							else
+								fuseGroups[childId] = childGroups[childId];
+						}
 					}
 				}
 			}
@@ -1134,7 +1137,7 @@ type ComboGridProps = {
 	fuseGroups: any;
 };
 
-const ComboGrid = ((props: ComboGridProps) => {
+const ComboGrid = (props: ComboGridProps) => {
 	const { crew, fuseGroups } = props;
 	let combos = [...props.combos];
 
@@ -1164,6 +1167,9 @@ const ComboGrid = ((props: ComboGridProps) => {
 		groupOptions = groups.map((group, groupId) => {
 			return { key: groupId, value: groupId, text: 'Option '+(groupId+1) };
 		});
+		// Only show first 200 options
+		if (groupOptions.length > 200)
+			groupOptions = groupOptions.slice(0, 200);
 	}
 
 	return (
@@ -1206,9 +1212,9 @@ const ComboGrid = ((props: ComboGridProps) => {
 	);
 
 	function cycleGroupOptions(): void {
-		if (groups.length <= 1) return;
-		setGroupIndex(groupIndex+1 < groups.length ? groupIndex+1 : 0);
+		if (groupOptions.length <= 1) return;
+		setGroupIndex(groupIndex+1 < groupOptions.length ? groupIndex+1 : 0);
 	}
-});
+};
 
 export default CrewRetrieval;


### PR DESCRIPTION
This limits the number of combo options to 200 per fuse group; it also limits calculation of options for up to 5 fuses. This should speed up viewing combos of certain crew members that have lots and lots of possible options without hurting usefulness that much. If slowdowns continue to be a problem or if we really want to display every single option, we might consider paging the results. This functionality is also a good candidate for a worker.

Uses a Gatsby `<Link>` to link crew names in the table to crew pages instead of using the onClick handler. This allows users to middle-click the names to open up pages in a new tab. We should update all searchable tables (e.g. index, crew player tool, event planner) to act the same way.