### PR TITLE
Fix voyage calc antimatter count

### DIFF
--- a/src/components/CONFIG.ts
+++ b/src/components/CONFIG.ts
@@ -30,20 +30,20 @@ export default class CONFIG {
 
 	static readonly SKILLS: { [index: string]: string } = {
 		command_skill: 'Command',
-		science_skill: 'Science',
-		security_skill: 'Security',
-		engineering_skill: 'Engineering',
 		diplomacy_skill: 'Diplomacy',
-		medicine_skill: 'Medicine'
+		engineering_skill: 'Engineering',
+		security_skill: 'Security',
+		medicine_skill: 'Medicine',
+		science_skill: 'Science'
 	};
 
 	static readonly SKILLS_SHORT = [
 		{ name: 'command_skill', short: 'CMD' },
-		{ name: 'science_skill', short: 'SCI' },
-		{ name: 'security_skill', short: 'SEC' },
-		{ name: 'engineering_skill', short: 'ENG' },
 		{ name: 'diplomacy_skill', short: 'DIP' },
-		{ name: 'medicine_skill', short: 'MED' }
+		{ name: 'engineering_skill', short: 'ENG' },
+		{ name: 'security_skill', short: 'SEC' },
+		{ name: 'medicine_skill', short: 'MED' },
+		{ name: 'science_skill', short: 'SCI' }
 	];
 
 	static readonly REWARDS_ITEM_TYPE: { [index: number]: string } = {

--- a/src/components/CONFIG.ts
+++ b/src/components/CONFIG.ts
@@ -30,20 +30,20 @@ export default class CONFIG {
 
 	static readonly SKILLS: { [index: string]: string } = {
 		command_skill: 'Command',
-		diplomacy_skill: 'Diplomacy',
-		engineering_skill: 'Engineering',
+		science_skill: 'Science',
 		security_skill: 'Security',
-		medicine_skill: 'Medicine',
-		science_skill: 'Science'
+		engineering_skill: 'Engineering',
+		diplomacy_skill: 'Diplomacy',
+		medicine_skill: 'Medicine'
 	};
 
 	static readonly SKILLS_SHORT = [
 		{ name: 'command_skill', short: 'CMD' },
-		{ name: 'diplomacy_skill', short: 'DIP' },
-		{ name: 'engineering_skill', short: 'ENG' },
+		{ name: 'science_skill', short: 'SCI' },
 		{ name: 'security_skill', short: 'SEC' },
-		{ name: 'medicine_skill', short: 'MED' },
-		{ name: 'science_skill', short: 'SCI' }
+		{ name: 'engineering_skill', short: 'ENG' },
+		{ name: 'diplomacy_skill', short: 'DIP' },
+		{ name: 'medicine_skill', short: 'MED' }
 	];
 
 	static readonly REWARDS_ITEM_TYPE: { [index: number]: string } = {

--- a/src/components/voyagecalculator.tsx
+++ b/src/components/voyagecalculator.tsx
@@ -14,21 +14,6 @@ import { useStateWithStorage } from '../utils/storage';
 import { CALCULATORS, CalculatorState } from '../utils/voyagehelpers';
 import { getEstimate } from '../workers/chewable.js';
 
-const VOYAGE_SEATS = [
-	'captain_slot',
-	'first_officer',
-	'chief_communications_officer',
-	'communications_officer',
-	'chief_security_officer',
-	'security_officer',
-	'chief_engineering_officer',
-	'engineering_officer',
-	'chief_science_officer',
-	'science_officer',
-	'chief_medical_officer',
-	'medical_officer'
-];
-
 type VoyageCalculatorProps = {
 	playerData: any;
 };
@@ -228,6 +213,7 @@ const VoyageEditConfigModal = (props: VoyageEditConfigModalProps) => {
 		{ symbol: 'medical_officer', name: 'Ship\'s Counselor', skill: 'medicine_skill', trait: '' }
 	];
 	const crewSlots = voyageConfig.crew_slots ?? defaultSlots;
+	crewSlots.sort((s1, s2) => CONFIG.VOYAGE_CREW_SLOTS.indexOf(s1.symbol) - CONFIG.VOYAGE_CREW_SLOTS.indexOf(s2.symbol));
 
 	return (
 		<Modal
@@ -420,7 +406,7 @@ const VoyageExisting = (props: VoyageExistingProps) => {
 
 		values = values.concat(voyageConfig
 			.crew_slots
-			.sort((s1, s2) => VOYAGE_SEATS.indexOf(s1.symbol) - VOYAGE_SEATS.indexOf(s2.symbol))
+			.sort((s1, s2) => CONFIG.VOYAGE_CREW_SLOTS.indexOf(s1.symbol) - CONFIG.VOYAGE_CREW_SLOTS.indexOf(s2.symbol))
 			.map(s => s.crew.name)
 		);
 
@@ -967,9 +953,9 @@ const VoyageResultPane = (props: VoyageResultPaneProps) => {
 		<React.Fragment>
 			{calcState == CalculatorState.Done && (
 				<Message attached>
-					Median runtime: <b>{formatTime(result.estimate.refills[0].result)}</b>{` `}
+					Estimate: <b>{formatTime(result.estimate.refills[0].result)}</b>{` `}
 					(expected range: {formatTime(result.estimate.refills[0].saferResult)} to{` `}
-						{formatTime(result.estimate.refills[0].moonshotResult)}).
+						{formatTime(result.estimate.refills[0].moonshotResult)})
 				</Message>
 			)}
 			<Tab.Pane>

--- a/src/components/voyagestats.tsx
+++ b/src/components/voyagestats.tsx
@@ -167,7 +167,7 @@ export class VoyageStats extends Component<VoyageStatsProps, VoyageStatsState> {
 
 		return (
 			<div>
-			  {ship && `Ship: ${ship.name} (${voyageData.max_hp} Antimatter)`}
+			  {ship && (<span>Ship : <b>{ship.name}</b></span>)}
 				<Grid columns={isMobile ? 1 : 2}>
 					<Grid.Column>
 						<ul>
@@ -189,6 +189,13 @@ export class VoyageStats extends Component<VoyageStatsProps, VoyageStatsState> {
 							</ul>
 						</Grid.Column>
 						<Grid.Column verticalAlign="middle">
+							<ul>
+								<li>
+									Antimatter
+									{' : '}
+									<b>{voyageData.max_hp}</b>
+								</li>
+							</ul>
 							<ul>
 								{Object.keys(CONFIG.SKILLS).map((entry, idx) => {
 									const agg = voyageData.skill_aggregates[entry];

--- a/src/utils/voyagehelpers.ts
+++ b/src/utils/voyagehelpers.ts
@@ -307,8 +307,7 @@ class IAmPicardHelper extends Helper {
 				slotId: i,
 				choice: crew,
 				hasTrait: crew
-					.traits_named
-					.map(trait => trait.toLowerCase())
+					.traits
 					.includes(this.voyageConfig.crew_slots[i].trait)
 			};
 
@@ -344,7 +343,7 @@ class IAmPicardHelper extends Helper {
 					entries,
 					aggregates,
 					startAM: config.startAm,
-					postscript: 'Recommended for median runtime ('+formatTime(message.data.result.refills[0].result)+')'
+					postscript: 'Recommended for estimated runtime ('+formatTime(message.data.result.refills[0].result)+')'
 				};
 				if (!inProgress) {
 					this.perf.end = performance.now();
@@ -499,7 +498,7 @@ class USSJohnJayHelper extends Helper {
 
 	_showRecommendedValue(sortOption: number, estimate: any): string {
 		const sortNames = [
-			'median runtime', 'guaranteed runtime', 'moonshot runtime', 'dilemma chance', 'starting antimatter'
+			'estimated runtime', 'guaranteed minimum', 'moonshot', 'dilemma chance', 'starting antimatter'
 		];
 		let sortValue = "";
 		switch (sortOption) {


### PR DESCRIPTION
Fixes starting antimatter count on original voyage calculator by using `traits` (symbols) instead of `traits_named` to match traits, which should handle multi-word traits and renamed traits more consistently.

Fixes seat order on voyage editor by sorting to match `CONFIG` crew slots in cases when `voyageConfig` order is different from expected order.

Based on feedback that recommendation descriptions still aren't as clear as they ought to be, this changes some terms to be more self-explanatory ("estimated runtime" instead of "median runtime", "guaranteed minimum" instead of "guaranteed runtime").

ETA: Re-ordering of skills constants removed from this PR. Will attempt that in a separate branch.