### PR TITLE
Invert skill icons on light mode

### DIFF
--- a/static/styles/semantic.css
+++ b/static/styles/semantic.css
@@ -19992,7 +19992,7 @@ ol.ui.horizontal.list li:before,
 .ui.ordered.steps .step.completed:before {
   font-family: 'Step';
   content: '\e800';
-  /* '' 
+  /* ''
 }
 
 /*******************************
@@ -40424,3 +40424,17 @@ body.pushable > .pusher {
 /*******************************
          Site Overrides
 *******************************/
+
+/* Specify icons to invert for light mode */
+img.skillIcon,
+img.traitIcon,
+/* Also catch unspecified skill icons by matching filename */
+img[src$="icon_command_skill.png"],
+img[src$="icon_diplomacy_skill.png"],
+img[src$="icon_engineering_skill.png"],
+img[src$="icon_medicine_skill.png"],
+img[src$="icon_science_skill.png"],
+img[src$="icon_security_skill.png"] {
+	-webkit-filter: invert(100%) grayscale(1);
+	filter: invert(100%) grayscale(1);
+}

--- a/static/styles/semantic.css
+++ b/static/styles/semantic.css
@@ -40426,8 +40426,7 @@ body.pushable > .pusher {
 *******************************/
 
 /* Specify icons to invert for light mode */
-img.skillIcon,
-img.traitIcon,
+img.invertibleIcon,
 /* Also catch unspecified skill icons by matching filename */
 img[src$="icon_command_skill.png"],
 img[src$="icon_diplomacy_skill.png"],
@@ -40435,6 +40434,6 @@ img[src$="icon_engineering_skill.png"],
 img[src$="icon_medicine_skill.png"],
 img[src$="icon_science_skill.png"],
 img[src$="icon_security_skill.png"] {
-	-webkit-filter: invert(100%) grayscale(1);
-	filter: invert(100%) grayscale(1);
+	-webkit-filter: invert(1) grayscale(1);
+	filter: invert(1) grayscale(1);
 }


### PR DESCRIPTION
This updates the light mode stylesheet to invert skill icons.

Ideally every skill icon image element should have a className (e.g. `skillIcon`) instead of hardcoding filenames, but this method catches every current use of skill icons without having to change every individual source file.

This also preps the inversion of trait (polestar) icons for light mode; just remember to add the `traitIcon` className to trait img elements the next time the relevant source files are edited.