### PR TITLE
Put up message when voyage time seems inaccurate

### DIFF
--- a/src/components/voyagestats.tsx
+++ b/src/components/voyagestats.tsx
@@ -425,6 +425,13 @@ export class VoyageStats extends Component<VoyageStatsProps, VoyageStatsState> {
 		if (voyState !== 'pending') {
 			return (
 				<div>
+					{Math.floor(voyageData.log_index/360) < Math.floor(voyageData.voyage_duration/7200) &&
+						<Message warning>
+							WARNING!!! A potential problem with the reported voyage duration has been detected.
+							The estimate is likely to be inaccurate.
+							Load the game then return to Datacore with a fresh copy of your player file to get an accurate estimate.
+						</Message>
+					}
 					<Message>Your voyage {voyState === 'failed' ? 'failed at ' :  'has been running for ' + this._formatTime(voyageData.voyage_duration/3600)}.</Message>
 					<Accordion fluid exclusive={false}>
 					{


### PR DESCRIPTION
Quick fix for when the wrong voyage time is reported. This occurs when there is an unresolved dilemma and the player hasn't opened the game. The voyage timer keeps counting. This can be detected by using another counter `log_index` which only updates while the game is open. Hence if these two measures are either side of a dilemma it is highly probable that this bug has occurred.

I am working on a fix that could correct the bug which will be part of the voyage-bugfixes PR but I think this needs a quick fix as it can result in hugely inaccurate estimates which would erode trust in the calculator. I have attached a `player.json` that replicates the bug: [voyage_bug.txt](https://github.com/stt-datacore/website/files/7614590/voyage_bug.txt)
