### PR TITLE
Fix event planner potential prospects bug

### DIFF
--- a/src/components/eventplanner.tsx
+++ b/src/components/eventplanner.tsx
@@ -256,7 +256,7 @@ const EventCrewTable = (props: EventCrewTableProps) => {
 			if (crew.bonus > 1 || showPotential) {
 				CONFIG.SKILLS_SHORT.forEach(skill => {
 					if (crew[skill.name].core > 0) {
-						if (showPotential && crew.immortal === 0) {
+						if (showPotential && crew.immortal === 0 && !crew.prospect) {
 							crew[skill.name].current = crew[skill.name].core*crew.bonus;
 							crew[skill.name] = applySkillBuff(buffConfig, skill.name, crew.skill_data[crew.rarity-1].base_skills[skill.name]);
 						}


### PR DESCRIPTION
This fixes the crash that happens when "Show potential skills" is checked at the same time a prospective crew has been added to the roster, by skipping an unnecessary attempt to applySkillBuff for prospects.