### PR TITLE
Fix behold by updating marked module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "localforage": "^1.9.0",
         "lodash": "^4.17.21",
         "lodash.combinations": "^18.10.0",
-        "marked": "^4.0.10",
+        "marked": "^4.0.12",
         "react": "^17.0.1",
         "react-device-detect": "^1.15.0",
         "react-dom": "^17.0.1",
@@ -14629,9 +14629,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -37431,9 +37431,9 @@
       }
     },
     "marked": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
     },
     "md5-file": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",
     "lodash.combinations": "^18.10.0",
-    "marked": "^4.0.10",
+    "marked": "^4.0.12",
     "react": "^17.0.1",
     "react-device-detect": "^1.15.0",
     "react-dom": "^17.0.1",

--- a/src/pages/behold.tsx
+++ b/src/pages/behold.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Header, Dropdown, Grid, Rating, Divider, Form, Popup, Label } from 'semantic-ui-react';
 import { Link } from 'gatsby';
-import marked from 'marked';
+import { marked } from 'marked';
 
 import Layout from '../components/layout';
 import CommonCrewData from '../components/commoncrewdata';
@@ -154,7 +154,7 @@ class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
 
 			// This emulates the Gatsby markdown output until the transition to dynamic loading entirely
 			entries.push({
-				markdown: marked(bcrew.markdownContent),
+				markdown: marked.parse(bcrew.markdownContent),
 				crew: this.state.allcrew.find(c => c.symbol === symbol),
 				crewDemands: {
 					factionOnlyTotal: bcrew.factionOnlyTotal,


### PR DESCRIPTION
This fixes the bug that's breaking the behold page right now by updating the marked node module and then importing it as a named import, per marked's current documentation.

Note this might still give a warning when building because marked as of v4.0.12 has no default export.