### PR TITLE
Big Book notes/crew table changes

### DIFF
--- a/src/components/cabexplanation.tsx
+++ b/src/components/cabexplanation.tsx
@@ -7,7 +7,6 @@ const text = (
     <p>CAB Power Ratings are a system designed to help rank crew by their overall value, taking into account factors including their voyage power, potential event usage, gauntlet power, collections, and more.</p>
     <p>You can find a detailed description of how the CAB STT Overall Power Rating is calculated on the Power Ratings website.</p>
     <p>DataCore shows both the "overall power rating", which is a decimal number, and the "overall rank", which tells you how a crew's overall power rating compares to other crew of the same rarity.</p>
-    <p>DataCore has added this information to give players more ways to sort and evaluate crew, which is particularly important now that the Big Book of Beholds has ceased operation.</p>
     <p>Like all ranks and ratings, CAB power ratings should only be considered a guide or tool - how valuable a crew is to a player depends on how much the player values different aspects of the game, and which crew a player already owns.</p>
   </>
 );

--- a/src/components/commoncrewdata.tsx
+++ b/src/components/commoncrewdata.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Header, Segment, Accordion, Statistic, Grid, Image, Label, Rating, StatisticGroup, Divider } from 'semantic-ui-react';
 
-import { graphql, Link } from 'gatsby';
+import { graphql, Link, navigate } from 'gatsby';
 
 import CrewStat from '../components/crewstat';
 import CONFIG from '../components/CONFIG';
@@ -154,7 +154,7 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 					<div style={{ textAlign: 'center' }}>
 						<StatLabel title="Voyage rank" value={crew.ranks.voyRank} />
 						<StatLabel title="Gauntlet rank" value={crew.ranks.gauntletRank} />
-						<StatLabel title="Big book tier (legacy)" value={formatTierLabel(markdownRemark.frontmatter.bigbook_tier)} />
+						<StatLabel title="Big book tier" value={formatTierLabel(markdownRemark.frontmatter.bigbook_tier)} />
 						{markdownRemark.frontmatter.events !== null && (
 							<StatLabel title="Events" value={markdownRemark.frontmatter.events} />
 						)}
@@ -171,7 +171,7 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 							</Statistic>
 						)}
 						<Statistic>
-							<Statistic.Label>Tier (Legacy)</Statistic.Label>
+							<Statistic.Label>Big Book Tier</Statistic.Label>
 							<Statistic.Value>{formatTierLabel(markdownRemark.frontmatter.bigbook_tier)}</Statistic.Value>
 						</Statistic>
 						<Statistic>
@@ -399,18 +399,34 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 	}
 }
 
-const rankLinker = (roster: any, rank: number, symbol: string, column: string, direction: string, searchFilter: string) => {
+const rankLinker = (roster: any, rank: number, symbol: string, column: string, direction: string, search: string) => {
 	if (roster) return (<>{rank}</>);
 	const linkState = {
-		searchFilter: searchFilter ?? '',
+		search: search ?? '',
 		column: column,
 		direction: direction ?? 'ascending',
-		paginationPage: Math.ceil(rank/10),
-		highlights: symbol ? [symbol] : []
+		highlight: symbol ?? ''
 	};
+	const baseUrl = '/';
+	let params = '';
+	Object.entries(linkState).forEach(entry => {
+		if (entry[1] !== '') {
+			if (params !== '') params += '&';
+			params += entry[0]+'='+encodeURI(entry[1]);
+		}
+	});
+	const url = params !== '' ? baseUrl+'?'+params : baseUrl;
 	return (
-		<Link to="/" state={linkState}>{rank}</Link>
+		<Link to={url} onClick={(event) => clickLink(event)}>{rank}</Link>
 	);
+
+	// On left clicks, use state instead of URL params because it's a little faster and cleaner
+	function clickLink(e) {
+		if (e.button === 0) {
+			e.preventDefault();
+			navigate(baseUrl, { state: linkState });
+		}
+	}
 };
 
 export default CommonCrewData;

--- a/src/components/crewretrieval.tsx
+++ b/src/components/crewretrieval.tsx
@@ -984,7 +984,7 @@ const CrewTable = (props: CrewTableProps) => {
 	const tableConfig: ITableConfigRow[] = [
 		{ width: 3, column: 'name', title: 'Crew' },
 		{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true, tiebreakers: ['highest_owned_rarity'] },
-		{ width: 1, column: 'bigbook_tier', title: 'Tier (Legacy)' },
+		{ width: 1, column: 'bigbook_tier', title: 'Tier' },
 		{ width: 1, column: 'cab_ov', title: 'CAB', reverse: true, tiebreakers: ['cab_ov_rank'] },
 		{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
 		{ width: 1, column: 'collections.length', title: 'Collections', reverse: true },

--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Table, Icon, Rating, Form, Checkbox, Header } from 'semantic-ui-react';
 import { Link, navigate } from 'gatsby';
 
-import { SearchableTable, ITableConfigRow, initSearchableOptions } from '../components/searchabletable';
+import { SearchableTable, ITableConfigRow, initSearchableOptions, initCustomOption } from '../components/searchabletable';
 
 import CONFIG from '../components/CONFIG';
 import CABExplanation from '../components/cabexplanation';
@@ -29,8 +29,8 @@ const ProfileCrew = (props: ProfileCrewProps) => {
 	//	Custom options are only available in player tool right now
 	let initOptions = initSearchableOptions(window.location);
 	// Check for custom initial profile_crew options from URL or <Link state>
-	const initHighlight = initOption(props.location, 'highlight', '');
-	const initProspects = initOption(props.location, 'prospect', []);
+	const initHighlight = initCustomOption(props.location, 'highlight', '');
+	const initProspects = initCustomOption(props.location, 'prospect', []);
 	// Clear history state now so that new stored values aren't overriden by outdated parameters
 	if (window.location.state && (initOptions || initHighlight || initProspects))
 		window.history.replaceState(null, '');
@@ -55,21 +55,6 @@ const ProfileCrew = (props: ProfileCrewProps) => {
 		}
 	}
 	return (<ProfileCrewTable crew={myCrew} initOptions={initOptions} lockable={lockable} />);
-
-	function initOption(location: any, option: string, defaultValue: any): any {
-		let value = undefined;
-		// Always use URL parameters if found
-		if (location?.search) {
-			const urlParams = new URLSearchParams(location.search);
-			if (urlParams.has(option)) value = Array.isArray(defaultValue) ? urlParams.getAll(option) : urlParams.get(option);
-		}
-		// Otherwise check <Link state>
-		if (!value && location?.state) {
-			const linkState = location.state;
-			if (linkState[option]) value = JSON.parse(JSON.stringify(linkState[option]));
-		}
-		return value ?? defaultValue;
-	}
 };
 
 type ProfileCrewTools = {
@@ -182,8 +167,9 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 	const myCrew = JSON.parse(JSON.stringify(props.crew));
 
 	const tableConfig: ITableConfigRow[] = [
-		{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events'] },
+		{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'events', 'collections.length'] },
 		{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true, tiebreakers: ['rarity'] },
+		{ width: 1, column: 'bigbook_tier', title: 'Tier' },
 		{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
 		{ width: 1, column: 'ranks.voyRank', title: 'Voyage' }
 	];
@@ -237,6 +223,9 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 				<Table.Cell>
 					<Rating icon='star' rating={crew.rarity} maxRating={crew.max_rarity} size="large" disabled />
 				</Table.Cell>
+				<Table.Cell textAlign="center">
+					<b>{formatTierLabel(crew.bigbook_tier)}</b>
+				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>{crew.cab_ov}</b><br />
 					<small>{rarityLabels[parseInt(crew.max_rarity)-1]} #{crew.cab_ov_rank}</small>
@@ -283,7 +272,7 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 					{crew.favorite && <Icon name="heart" />}
 					{crew.prospect && <Icon name="add user" />}
 					<span>Level {crew.level}, </span>
-					{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)}, </>}{formattedCounts}
+					{formattedCounts}
 				</div>
 			);
 		}

--- a/src/components/prospectpicker.tsx
+++ b/src/components/prospectpicker.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Table, Rating, Dropdown, Button } from 'semantic-ui-react';
+import { Link } from 'gatsby';
+
+type ProspectPickerProps = {
+	pool: any[];
+	prospects: any[];
+	setProspects: (prospects: any[]) => void;
+};
+
+const ProspectPicker = (props: ProspectPickerProps) => {
+	const { pool, prospects, setProspects } = props;
+
+	enum OptionsState {
+		Uninitialized,
+		Initializing,
+		Ready
+	};
+
+	const [selection, setSelection] = React.useState('');
+	const [options, setOptions] = React.useState({
+		state: OptionsState.Uninitialized,
+		list: []
+	});
+
+	if (pool.length == 0) return (<></>);
+
+	const placeholder = options.state === OptionsState.Initializing ? 'Loading. Please wait...' : 'Select Crew';
+
+	return (
+		<React.Fragment>
+			<Dropdown search selection clearable
+				placeholder={placeholder}
+				options={options.list}
+				value={selection}
+				onFocus={() => { if (options.state === OptionsState.Uninitialized) populateOptions(); }}
+				onChange={(e, { value }) => setSelection(value)}
+			/>
+			<Button compact icon='add user' color='green' content='Add Crew' onClick={() => { addProspect(); }} style={{ marginLeft: '1em' }} />
+			<Table celled striped collapsing unstackable compact="very">
+				<Table.Body>
+					{prospects.map((p, prospectNum) => (
+						<Table.Row key={prospectNum}>
+							<Table.Cell><img width={24} src={`${process.env.GATSBY_ASSETS_URL}${p.imageUrlPortrait}`} /></Table.Cell>
+							<Table.Cell><Link to={`/crew/${p.symbol}/`}>{p.name}</Link></Table.Cell>
+							<Table.Cell>
+								<Rating size='large' icon='star' rating={p.rarity} maxRating={p.max_rarity}
+									onRate={(e, {rating, maxRating}) => { fuseProspect(prospectNum, rating); }} />
+							</Table.Cell>
+							<Table.Cell>
+								<Button compact icon='trash' color='red' onClick={() => deleteProspect(prospectNum)} />
+							</Table.Cell>
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table>
+		</React.Fragment>
+	);
+
+	function populateOptions(): void {
+		setOptions({
+			state: OptionsState.Initializing,
+			list: []
+		});
+		// Populate inside a timeout so that UI can update with a "Loading" placeholder first
+		setTimeout(() => {
+			const populatePromise = new Promise((resolve, reject) => {
+				const poolList = pool.map((c) => (
+					{
+						key: c.symbol,
+						value: c.symbol,
+						image: { avatar: true, src: `${process.env.GATSBY_ASSETS_URL}${c.imageUrlPortrait}` },
+						text: c.name
+					}
+				));
+				resolve(poolList);
+			});
+			populatePromise.then((poolList) => {
+				setOptions({
+					state: OptionsState.Initialized,
+					list: poolList
+				});
+			});
+		}, 0);
+	}
+
+	function addProspect(): void {
+		if (selection == '') return;
+		let valid = pool.find((c) => c.symbol == selection);
+		if (valid) {
+			let prospect = {
+				symbol: valid.symbol,
+				name: valid.name,
+				imageUrlPortrait: valid.imageUrlPortrait,
+				rarity: valid.max_rarity,
+				max_rarity: valid.max_rarity
+			};
+			prospects.push(prospect);
+			setProspects([...prospects]);
+		};
+		setSelection('');
+	}
+
+	function fuseProspect(prospectNum: number, rarity: number): void {
+		if (rarity == 0) return;
+		prospects[prospectNum].rarity = rarity;
+		setProspects([...prospects]);
+	}
+
+	function deleteProspect(prospectNum: number): void {
+		prospects.splice(prospectNum, 1);
+		setProspects([...prospects]);
+	}
+};
+
+export default ProspectPicker;

--- a/src/components/searchabletable.tsx
+++ b/src/components/searchabletable.tsx
@@ -126,7 +126,7 @@ export const SearchableTable = (props: SearchableTableProps) => {
 						onClick={() => onHeaderClick(cell)}
 						textAlign={cell.width === 1 ? 'center' : 'left'}
 					>
-						{cell.title}{cell.pseudocolumns?.includes(column) && <><br/><small>{column.replace('_',' ')}</small></>}
+						{cell.title}{cell.pseudocolumns?.includes(column) && <><br/><small>{column.replace('_',' ').replace('.length', '')}</small></>}
 					</Table.HeaderCell>
 				))}
 			</Table.Row>

--- a/src/pages/behold.tsx
+++ b/src/pages/behold.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Header, Dropdown, Grid, Rating, Divider, Form, Popup, Label } from 'semantic-ui-react';
-import { Link } from 'gatsby';
+import { Header, Dropdown, Grid, Rating, Divider, Form, Popup, Label, Button } from 'semantic-ui-react';
+import { Link, navigate } from 'gatsby';
 import marked from 'marked';
 
 import Layout from '../components/layout';
@@ -24,12 +24,11 @@ type BeholdsPageState = {
 };
 
 const rarityOptions = [
-	{ key: null, value: null, text: 'Any' },
-	{ key: '1', value: '1', text: '1' },
-	{ key: '2', value: '2', text: '2' },
-	{ key: '3', value: '3', text: '3' },
-	{ key: '4', value: '4', text: '4' },
-	{ key: '5', value: '5', text: '5' }
+	{ key: 'ro0', value: null, text: 'Any rarity' },
+	{ key: 'ro2', value: '2', text: 'Minimum 2*' },
+	{ key: 'ro3', value: '3', text: 'Minimum 3*' },
+	{ key: 'ro4', value: '4', text: 'Minimum 4*' },
+	{ key: 'ro5', value: '5', text: 'Minimum 5*' }
 ];
 
 class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
@@ -94,8 +93,7 @@ class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
 
 		return (
 			<Layout title='Behold helper / crew comparison'>
-				<Header as='h4'>Behold helper / crew comparison</Header>
-				<p>Simply search for the crew you want to compare to get side-by-side views for comparison.</p>
+				<Header as='h2'>Behold helper / crew comparison</Header>
 				<Form>
 					<Form.Group>
 						<Dropdown
@@ -106,7 +104,7 @@ class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
 							selection
 							closeOnChange
 							options={peopleToShow}
-							placeholder='Select or search for crew'
+							placeholder='Search for crew to compare'
 							label='Behold crew'
 							value={this.state.currentSelectedItems}
 							onChange={(e, { value }) => this._selectionChanged(value)}
@@ -121,6 +119,9 @@ class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
 						/>
 					</Form.Group>
 				</Form>
+				{this.state.currentSelectedItems?.length > 0 && (
+					<Button compact icon='add user' color='green' content='Preview all in your roster' onClick={() => { this._addProspects(); }} />
+				)}
 
 				<Divider horizontal hidden />
 
@@ -134,7 +135,14 @@ class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
 								</Link>
 							</Header>
 							<CommonCrewData compact={true} crewDemands={entry.crewDemands} crew={entry.crew} markdownRemark={entry.markdownRemark} roster={this.state.roster}/>
-							{entry.markdown && <div dangerouslySetInnerHTML={{ __html: entry.markdown }} />}
+							{entry.markdown && (
+								<React.Fragment>
+									<div dangerouslySetInnerHTML={{ __html: entry.markdown }} />
+									<div style={{ marginTop: '1em' }}>
+										<a href={`https://www.bigbook.app/crew/${entry.crew.symbol}`}>View {entry.crew.name} on Big Book</a>
+									</div>
+								</React.Fragment>
+							)}
 						</Grid.Column>
 					))}
 				</Grid>
@@ -177,6 +185,14 @@ class BeholdsPage extends Component<BeholdsPageProps, BeholdsPageState> {
 
 		let newurl = window.location.protocol + '//' + window.location.host + window.location.pathname + '?' + params.toString();
 		window.history.pushState({ path: newurl }, '', newurl);
+	}
+
+	_addProspects(): void {
+		const linkUrl = '/playertools?tool=crew';
+		const linkState = {
+			prospect: this.state.currentSelectedItems
+		};
+		navigate(linkUrl, { state: linkState });
 	}
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { Header, Table, Rating, Icon, Dropdown, Popup } from 'semantic-ui-react';
-import { navigate } from 'gatsby';
+import { Link, navigate } from 'gatsby';
 
 import Layout from '../components/layout';
-import { SearchableTable, ITableConfigRow } from '../components/searchabletable';
+import { SearchableTable, ITableConfigRow, initSearchableOptions } from '../components/searchabletable';
 import Announcement from '../components/announcement';
 
 import CONFIG from '../components/CONFIG';
@@ -14,26 +14,32 @@ import CABExplanation from '../components/cabexplanation';
 
 const rarityLabels = ['Common', 'Uncommon', 'Rare', 'Super Rare', 'Legendary'];
 
-type IndexPageProps = {};
+type IndexPageProps = {
+	data: any;
+	location: any;
+};
 
 type IndexPageState = {
 	botcrew: any[];
 	initOptions: any;
-	highlights: string[];
+	lockable: any[];
 };
 
 const tableConfig: ITableConfigRow[] = [
-	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'bigbook_tier', 'events', 'date_added'] },
+	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'events', 'date_added'] },
 	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true },
+	{ width: 1, column: 'bigbook_tier', title: 'Tier' },
 	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
-	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' },
-	{ width: 1, column: 'command_skill', title: <img alt="Command" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_command_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
-	{ width: 1, column: 'science_skill', title: <img alt="Science" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_science_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
-	{ width: 1, column: 'security_skill', title: <img alt="Security" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_security_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
-	{ width: 1, column: 'engineering_skill', title: <img alt="Engineering" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_engineering_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
-	{ width: 1, column: 'diplomacy_skill', title: <img alt="Diplomacy" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_diplomacy_skill.png`} style={{ height: '1.1em' }} />, reverse: true },
-	{ width: 1, column: 'medicine_skill', title: <img alt="Medicine" src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_medicine_skill.png`} style={{ height: '1.1em' }} />, reverse: true }
+	{ width: 1, column: 'ranks.voyRank', title: 'Voyage' }
 ];
+CONFIG.SKILLS_SHORT.forEach((skill) => {
+	tableConfig.push({
+		width: 1,
+		column: `${skill.name}`,
+		title: <img alt={CONFIG.SKILLS[skill.name]} src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${skill.name}.png`} style={{ height: '1.1em' }} />,
+		reverse: true
+	});
+});
 
 class IndexPage extends Component<IndexPageProps, IndexPageState> {
 	constructor(props) {
@@ -41,7 +47,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 		this.state = {
 			botcrew: [],
 			initOptions: false,
-			highlights: []
+			lockable: []
 		};
 	}
 
@@ -57,35 +63,45 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 		});
 
 		// Check for custom initial table options from URL or <Link state>
-		let initOptions = false, highlights = [];
-		const OPTIONS = ['searchFilter', 'filterType', 'column', 'direction', 'paginationRows', 'paginationPage'];
-
-		// Always use URL search parameter if found
-		//	TODO: Allow URL parameters for all options (with validation) so we can permalink search results
-		let urlParams = new URLSearchParams(this.props.location.search);
-		if (urlParams.has('search')) {
-			initOptions = { searchFilter: urlParams.get('search') };
-		}
-		// Otherwise check <Link state>
-		else if (this.props.location.state) {
-			const linkState = this.props.location.state;
-			OPTIONS.forEach((option) => {
-				if (linkState[option]) {
-					if (!initOptions) initOptions = {};
-					initOptions[option] = linkState[option];
-				}
-			});
-			if (linkState.highlights) highlights = linkState.highlights;
-			// Clear history state now so that new stored values aren't overriden by outdated parameters
+		const initOptions = initSearchableOptions(this.props.location);
+		// Check for custom initial index options from URL or <Link state>
+		const initHighlight = initOption(this.props.location, 'highlight', '');
+		// Clear history state now so that new stored values aren't overriden by outdated parameters
+		if (this.props.location.state && (initOptions || initHighlight))
 			window.history.replaceState(null, '');
+
+		const lockable = [];
+		if (initHighlight != '') {
+			const highlighted = botcrew.find(c => c.symbol === initHighlight);
+			if (highlighted) {
+				lockable.push({
+					symbol: highlighted.symbol,
+					name: highlighted.name
+				});
+			}
 		}
 
-		this.setState({ botcrew, initOptions, highlights });
+		this.setState({ botcrew, initOptions, lockable });
+
+		function initOption(location: any, option: string, defaultValue: any): any {
+			let value = undefined;
+			// Always use URL parameters if found
+			if (location?.search) {
+				const urlParams = new URLSearchParams(location.search);
+				if (urlParams.has(option)) value = Array.isArray(defaultValue) ? urlParams.getAll(option) : urlParams.get(option);
+			}
+			// Otherwise check <Link state>
+			if (!value && location?.state) {
+				const linkState = location.state;
+				if (linkState[option]) value = JSON.parse(JSON.stringify(linkState[option]));
+			}
+			return value ?? defaultValue;
+		}
 	}
 
-	renderTableRow(crew: any): JSX.Element {
-		const highlighted = {
-			positive: this.state.highlights.indexOf(crew.symbol) >= 0
+	renderTableRow(crew: any, idx: number, highlighted: boolean): JSX.Element {
+		const attributes = {
+			positive: highlighted
 		};
 
 		const counts = [
@@ -99,7 +115,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 		)).reduce((prev, curr) => [prev, ' ', curr]);
 
 		return (
-			<Table.Row key={crew.symbol} style={{ cursor: 'zoom-in' }} onClick={() => navigate(`/crew/${crew.symbol}/`)} {...highlighted}>
+			<Table.Row key={crew.symbol} style={{ cursor: 'zoom-in' }} onClick={() => navigate(`/crew/${crew.symbol}/`)} {...attributes}>
 				<Table.Cell>
 					<div
 						style={{
@@ -112,15 +128,18 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 							<img width={48} src={`${process.env.GATSBY_ASSETS_URL}${crew.imageUrlPortrait}`} />
 						</div>
 						<div style={{ gridArea: 'stats' }}>
-							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}>{crew.name}</span>
+							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}><Link to={`/crew/${crew.symbol}/`}>{crew.name}</Link></span>
 						</div>
 						<div style={{ gridArea: 'description' }}>
-							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)} (Legacy), </>}{formattedCounts}
+							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)}, </>}{formattedCounts}
 						</div>
 					</div>
 				</Table.Cell>
 				<Table.Cell>
 					<Rating icon='star' rating={crew.max_rarity} maxRating={crew.max_rarity} size='large' disabled />
+				</Table.Cell>
+				<Table.Cell textAlign="center">
+					<b>{formatTierLabel(crew.bigbook_tier)}</b>
 				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>{crew.cab_ov}</b><br />
@@ -147,7 +166,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 	}
 
 	render() {
-		const { botcrew, initOptions } = this.state;
+		const { botcrew, initOptions, lockable } = this.state;
 		if (!botcrew || botcrew.length === 0) {
 			return (
 				<Layout>
@@ -166,14 +185,15 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 					id="index"
 					data={botcrew}
 					config={tableConfig}
-					renderTableRow={crew => this.renderTableRow(crew)}
+					renderTableRow={(crew, idx, highlighted) => this.renderTableRow(crew, idx, highlighted)}
 					filterRow={(crew, filter, filterType) => crewMatchesSearchFilter(crew, filter, filterType)}
 					initOptions={initOptions}
 					showFilterOptions={true}
+					lockable={lockable}
 				/>
 
 				<p>
-					<i>Hint</i> Click on a row to get details on that specific crew
+					<i>Hint</i>: Click on a row to get details on that specific crew
 				</p>
 			</Layout>
 		);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,7 @@ type IndexPageState = {
 };
 
 const tableConfig: ITableConfigRow[] = [
-	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'events', 'date_added'] },
+	{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'events', 'collections.length', 'date_added'] },
 	{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true },
 	{ width: 1, column: 'bigbook_tier', title: 'Tier' },
 	{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
@@ -131,7 +131,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 							<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}><Link to={`/crew/${crew.symbol}/`}>{crew.name}</Link></span>
 						</div>
 						<div style={{ gridArea: 'description' }}>
-							{crew.bigbook_tier > 0 && <>Tier {formatTierLabel(crew.bigbook_tier)}, </>}{formattedCounts}
+							{formattedCounts}
 						</div>
 					</div>
 				</Table.Cell>

--- a/src/pages/playertools.tsx
+++ b/src/pages/playertools.tsx
@@ -32,7 +32,7 @@ export const playerTools = {
 	},
 	'crew': {
 		title: 'Crew',
-		render: ({playerData}) => <ProfileCrew playerData={playerData} isTools={true} />
+		render: ({playerData, allCrew, location}) => <ProfileCrew playerData={playerData} isTools={true} allCrew={allCrew} location={location} />
 	},
 	'crew-mobile': {
 		title: 'Crew (mobile)',
@@ -75,7 +75,7 @@ export const playerTools = {
 	}
 };
 
-const PlayerToolsPage = () =>  {
+const PlayerToolsPage = (props: any) =>  {
 	const [playerData, setPlayerData] = React.useState(undefined);
 	const [inputPlayerData, setInputPlayerData] = React.useState(undefined);
 
@@ -92,7 +92,6 @@ const PlayerToolsPage = () =>  {
 	const [dataSource, setDataSource] = React.useState(undefined);
 	const [showForm, setShowForm] = React.useState(false);
 
-
 	// Profile data ready, show player tool panes
 	if (playerData && !showForm) {
 		return (<PlayerToolsPanes
@@ -106,6 +105,7 @@ const PlayerToolsPage = () =>  {
 					allItems={allItems}
 					requestShowForm={setShowForm}
 					requestClearData={clearPlayerData}
+					location={props.location}
 				/>);
 	}
 
@@ -223,6 +223,7 @@ type PlayerToolsPanesProps = {
 	allItems?: any;
 	requestShowForm: (showForm: boolean) => void;
 	requestClearData: () => void;
+	location: any;
 };
 
 const PlayerToolsPanes = (props: PlayerToolsPanesProps) => {

--- a/src/templates/crewpage.tsx
+++ b/src/templates/crewpage.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import { Header, Image, Divider, Grid, Segment, Rating, Dropdown, Popup, Label, Button, Comment } from 'semantic-ui-react';
-import { graphql } from 'gatsby';
+import { graphql, navigate } from 'gatsby';
 
 import SimpleMDE from 'react-simplemde-editor';
 import marked from 'marked';
@@ -141,6 +141,10 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 						<Grid.Column width={12}>
 							<CommonCrewData crew={crew} markdownRemark={markdownRemark} />
 
+							<div style={{ margin: '1em 0', textAlign: 'right' }}>
+								<Button icon='add user' color='green' content='Preview in your roster' onClick={() => { this._addProspect(crew); }} />
+							</div>
+
 							{this.state.items.length > 0 ? (
 								<React.Fragment>
 									{this.renderEquipment(crew)}
@@ -273,6 +277,14 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 			.catch(err => {
 				console.error(err);
 			});
+	}
+
+	_addProspect(crew: any): void {
+		const linkUrl = '/playertools?tool=crew';
+		const linkState = {
+			prospect: [crew.symbol]
+		};
+		navigate(linkUrl, { state: linkState });
 	}
 
 	renderEquipment(crew) {

--- a/src/templates/crewpage.tsx
+++ b/src/templates/crewpage.tsx
@@ -198,7 +198,14 @@ class StaticCrewPage extends Component<StaticCrewPageProps, StaticCrewPageState>
 					</Grid.Row>
 				</Grid>
 				<Divider horizontal hidden />
-				{hasBigBookEntry && <div dangerouslySetInnerHTML={{ __html: markdownRemark.html }} />}
+				{hasBigBookEntry && (
+					<React.Fragment>
+						<div dangerouslySetInnerHTML={{ __html: markdownRemark.html }} />
+						<div style={{ marginTop: '1em', textAlign: 'right' }}>
+							-- <a href={`https://www.bigbook.app/crew/${crew.symbol}`}>The Big Book of Behold Advice</a>
+						</div>
+					</React.Fragment>
+				)}
 				{/*userName && (
 						<div>
 							<br />

--- a/static/pages/about.md
+++ b/static/pages/about.md
@@ -29,6 +29,6 @@ Some code used to build this site was originally authored by IAmPicard (c) 2017 
 
 Most of the code for the website, the bot and accompanying services was originally authored by TemporalAgent7 (c) 2019 – 2020 and released under the MIT license.
 
-Some crew notes are imported from (the now discontinued) [The Big Book of Behold Advice](https://docs.google.com/spreadsheets/d/1CYR5jnqtacbQM9MIsXp6ATs84Q3rbRM3SmKmUtBvlJ0), created by [u/Automaton_2000](https://reddit.com/user/Automaton_2000). Some nicknames are imported from a curated sheet maintained by DCPilot. [STT Power Ratings](https://sttpowerratings.com/) are maintained by A Traveling Man & Cymru Am Byth. Content used with their permission.
+Some crew notes are imported from [The Big Book of Behold Advice](https://www.bigbook.app/), created by [u/Automaton_2000](https://reddit.com/user/Automaton_2000). Some nicknames are imported from a curated sheet maintained by DCPilot. [STT Power Ratings](https://sttpowerratings.com/) are maintained by A Traveling Man & Cymru Am Byth. Content used with their permission.
 
 This project is licensed under MIT, and if you choose to contribute code or other media you agree that your contributions will be licensed under its [MIT license](https://github.com/stt-datacore/website/blob/master/LICENSE).

--- a/static/pages/cab.md
+++ b/static/pages/cab.md
@@ -8,4 +8,4 @@ CAB Power Ratings are a system designed to help rank crew by their overall value
 
 DataCore shows both the "overall power rating", which is a decimal number, and the "overall rank", which tells you how a crew's overall power rating compares to other crew of the same rarity.
 
-DataCore has added this information to give players more ways to sort and evaluate crew, which is particularly important now that the Big Book of Beholds has ceased operation. Like all ranks and ratings, CAB power ratings should only be considered a guide or tool - how valuable a crew is to a player depends on how much the player values different aspects of the game, and which crew a player already owns.
+DataCore has added this information to give players more ways to sort and evaluate crew. Like all ranks and ratings, CAB power ratings should only be considered a guide or tool - how valuable a crew is to a player depends on how much the player values different aspects of the game, and which crew a player already owns.


### PR DESCRIPTION
Removes Big Book legacy tags and discontinued notes from index, crew page, crew player tool, crew retrieval, behold tool, and about page. Adds relevant links to bigbook.app from crew and behold pages, as requested. Re-adds Tier column to crew table on index page.

Uses a Gatsby `<Link>` to link crew names in the crew tables (on index and crew player tool) to their respective crew pages. This allows users to middle-click the names to open up pages in a new tab, similar to changes already approved in #315 and #317.

Skills headings in `tableConfig` (on index and crew player tool) are now dynamically generated so that they match skill order as defined in CONFIG. This means we can now re-order the skills in CONFIG without needing to update child components individually, similar to changes approved in #317.

Updates searchableTable to accept search parameters from the URL and state. Changes highlighting logic and introduces buttons to the top of the table to quickly jump to highlighted crew and "lock" them into view when re-sorting.

Adds the ability to add prospective crew to the crew player tool (using a new prospectpicker component).

Adds a button on the behold page to let you preview the choices on your roster (i.e. adds them as prospects to the crew player tool by passing params to searchabletable in state).

Some of these changes were first demoed in #322, but I moved them here because they affected many of the same files. The skill depth table introduced in #322 is NOT included here as it still needs work and will probably be moved to its own page.