### PR TITLE
Events page and event details modal

### DIFF
--- a/src/components/event_info_modal.tsx
+++ b/src/components/event_info_modal.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {Container, Header, Image, Tab } from 'semantic-ui-react';
+
+import EventInformationTab from './event_info_tabs/event_information';
+import ThresholdRewardsTab from './event_info_tabs/threshold_rewards';
+import RankedRewardsTab from './event_info_tabs/ranked_rewards';
+import LeaderboardTab from './event_info_tabs/leaderboard';
+
+type EventInfoModalProps = {
+	instanceId: number,
+	image: string,
+	hasDetails: boolean,
+	leaderboard: Array<object>,
+}
+
+function EventInfoModal({instanceId, image, hasDetails, leaderboard}: EventInfoModalProps) {
+	const [eventData, setEventData] = React.useState(null);
+
+	React.useEffect(() => {
+		async function fetchEventData() {
+			if (hasDetails) {
+				const fetchResp = await fetch(`/structured/events/${instanceId}.json`);
+				const data = await fetchResp.json();
+				setEventData(data);
+			}
+		}
+
+		fetchEventData();
+	}, []);
+
+	const eventInfoPanes = [
+		{
+			menuItem: 'Event Information',
+			render: () => (
+				<Tab.Pane attached={false}>
+					<EventInformationTab eventData={eventData} />
+				</Tab.Pane>
+			),
+		},
+		{
+			menuItem: 'Threshold Rewards',
+			render: () => (
+				<Tab.Pane attached={false}>
+					<ThresholdRewardsTab eventData={eventData} />
+				</Tab.Pane>
+			),
+		},
+		{
+			menuItem: 'Ranked Rewards',
+			render: () => (
+				<Tab.Pane attached={false}>
+					<RankedRewardsTab eventData={eventData} />
+				</Tab.Pane>
+			),
+		},
+	];
+
+	const leaderboardPane = [
+		{
+			menuItem: 'Leaderboard',
+			render: () => (
+				<Tab.Pane attached={false}>
+					<LeaderboardTab leaderboard={leaderboard} />
+				</Tab.Pane>
+			),
+		},
+	];
+
+	let panes;
+	if (hasDetails && eventData) {
+		panes = eventInfoPanes.concat(leaderboardPane);
+	} else {
+		panes = leaderboardPane;
+	}
+
+	return (
+		<Container style={{ padding: '1em' }}>
+			<Image
+				src={`${process.env.GATSBY_ASSETS_URL}${image}`}
+				fluid
+			/>
+			<Tab
+				style={{marginTop: '1em'}}
+				menu={{secondary: true, pointing: true}}
+				panes={panes}
+				renderActiveOnly
+			/>
+		</Container>
+	);
+}
+
+export default EventInfoModal;

--- a/src/components/event_info_tabs/crew_card.tsx
+++ b/src/components/event_info_tabs/crew_card.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Card, Image } from 'semantic-ui-react';
+import { getRarityColor } from '../../utils/assets';
+
+function getRarityStars(rarity: number) {
+	const retVal = [];
+	for (let i = 0; i < rarity; ++i) {
+		retVal.push('\u2605');
+	}
+	return retVal.join('');
+}
+
+function CrewCard({crew}) {
+    return (
+        <Card>
+            <Card.Content>
+                <Image
+                    floated="left"
+                    size="tiny"
+                    src={crew.image}
+                    bordered
+                    style={{
+                        borderColor: `${getRarityColor(crew.rarity)}`
+                    }}
+                />
+                <Card.Header>{crew.name}</Card.Header>
+                <Card.Meta>
+                    <p>{getRarityStars(crew.rarity)}</p>
+                    <p>
+                        {crew.skills.map(skill => (
+                            <Image key={skill.key} width={30} height={30} inline spaced src={skill.imageUrl} />
+                        ))}
+                    </p>
+                </Card.Meta>
+                <Card.Description>
+                    {crew.traits.join(', ')}
+                </Card.Description>
+            </Card.Content>
+        </Card>
+    );
+}
+
+export default CrewCard;

--- a/src/components/event_info_tabs/event_information.tsx
+++ b/src/components/event_info_tabs/event_information.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { graphql, useStaticQuery } from 'gatsby';
+import { Header, Card, Label, Image } from 'semantic-ui-react';
+
+import { getIconPath, getRarityColor } from '../../utils/assets';
+import { getEventData } from '../../utils/events';
+import CrewCard from './crew_card';
+
+type Content = {
+	content_type: string,
+};
+
+const contentTypeMap = {
+	gather: 'Galaxy',
+	shuttles: 'Faction',
+	skirmish: 'Skirmish',
+	expedition: 'Expedition',
+};
+
+function getEventType(contentTypes: string[]) {
+	const mappedTypes = contentTypes.map(type => contentTypeMap[type]);
+	const items = new Set(mappedTypes);
+	return [...items].join(' / ');
+}
+
+function sortCrew(crewArray) {
+	let groups = [
+		[],
+		[], // common
+		[], // uncommon
+		[], // rare
+		[], // very rare
+		[]  // legendary
+	];
+	// organize each crew into rarity buckets
+	crewArray.forEach(crew => {
+		groups[crew.max_rarity].push(crew);
+	});
+	// sort by name
+	groups = groups.map(group => group.sort((a, b) => a.name < b.name ? -1 : 1));
+	// reverse the list so legendary is first
+	groups.reverse();
+	// flatten the array of arrays
+	return groups.flat();
+}
+
+function EventInformationTab({eventData}) {
+	const {crewJson} = useStaticQuery(graphql`
+		query {
+			crewJson: allCrewJson {
+				edges {
+					node {
+						name
+						symbol
+						max_rarity
+						imageUrlPortrait
+					}
+				}
+			}
+		}
+	`);
+	const crewData = crewJson.edges.map(edge => edge.node);
+
+	const {
+		name,
+		description,
+		bonus_text,
+		content_types,
+		featured_crew
+	} = eventData;
+
+	const featuredCrewData = featured_crew.map(crew => ({
+		key: `crew_${crew.id}`,
+		name: crew.full_name,
+		image: getIconPath(crew.portrait),
+		rarity: crew.rarity,
+		skills: Object.keys(crew.skills).map(skill => ({
+			key: skill,
+			imageUrl: `${process.env.GATSBY_ASSETS_URL}atlas/icon_${skill}.png`
+		})),
+		traits: crew.traits.map(trait => `${trait[0].toUpperCase()}${trait.substr(1).replace(/_/g, ' ')}`),
+	}));
+
+	const {bonus, featured} = getEventData(eventData);
+	const bonusCrew = crewData.filter(crew => bonus.includes(crew.symbol) && !featured.includes(crew.symbol));
+
+	return (
+		<>
+			<Card fluid raised>
+				<Card.Content>
+					<Card.Header>{name}</Card.Header>
+					<Card.Meta>{getEventType(content_types)}</Card.Meta>
+					<Card.Description>{description}</Card.Description>
+				</Card.Content>
+				<Card.Content extra>
+					<p>{bonus_text}</p>
+				</Card.Content>
+			</Card>
+			<Header as="h3">Featured Crew</Header>
+			<Card.Group>
+				{featuredCrewData.map(crew => (
+					<CrewCard key={crew.key} crew={crew} />
+				))}
+			</Card.Group>
+			<Header as="h3">Bonus Crew</Header>
+			{bonusCrew.length === 0 && (
+				<p>Bonus crew not yet determined for this event.</p>
+			)}
+			{sortCrew(bonusCrew).map(crew => (
+				<Label key={`crew_${crew.symbol}`} color="black" style={{marginBottom: '5px'}}>
+					<Image
+						src={getIconPath({file: crew.imageUrlPortrait})}
+						size="massive"
+						inline
+						spaced="right"
+						bordered
+						style={{
+							borderColor: getRarityColor(crew.max_rarity)
+						}}
+						alt={crew.name}
+					/>
+					{crew.name}
+				</Label>
+			))}
+		</>
+	);
+}
+
+export default EventInformationTab;

--- a/src/components/event_info_tabs/leaderboard.tsx
+++ b/src/components/event_info_tabs/leaderboard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Message, Table } from 'semantic-ui-react';
+
+import { getIconPath } from '../../utils/assets';
+
+function LeaderboardTab({leaderboard}) {
+	return (
+		<>
+			<Message>
+				If this event is currently active, the leaderboard below might be out of date.
+				(Data is updated only a couple of times a week)
+			</Message>
+			<Table celled striped compact='very'>
+				<Table.Body>
+					{leaderboard.map(member => (
+						<Table.Row key={member.dbid}>
+							<Table.Cell style={{ fontSize: '1.25em' }}>
+								Rank: {member.rank}
+							</Table.Cell>
+							<Table.Cell>
+								<div
+									style={{
+										display: 'grid',
+										gridTemplateColumns: '60px auto',
+										gridTemplateAreas: `'icon stats' 'icon description'`,
+										gridGap: '1px'
+									}}>
+									<div style={{ gridArea: 'icon' }}>
+										<img
+											width={48}
+											src={member.avatar ? getIconPath(member.avatar) : `${process.env.GATSBY_ASSETS_URL}crew_portraits_cm_empty_sm.png`}
+										/>
+									</div>
+									<div style={{ gridArea: 'stats' }}>
+										<span style={{ fontWeight: 'bolder', fontSize: '1.25em' }}>
+											{member.display_name}
+										</span>
+									</div>
+									<div style={{ gridArea: 'description' }}>
+										Level {member.level}
+									</div>
+								</div>
+							</Table.Cell>
+							<Table.Cell style={{ fontSize: '1.25em' }}>
+								Score: {member.score}
+							</Table.Cell>
+						</Table.Row>
+					))}
+				</Table.Body>
+			</Table>
+		</>
+	);
+}
+
+export default LeaderboardTab;

--- a/src/components/event_info_tabs/ranked_rewards.tsx
+++ b/src/components/event_info_tabs/ranked_rewards.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Table, Image, Label } from 'semantic-ui-react';
+
+import { getIconPath, getRarityColor } from '../../utils/assets';
+
+function getBracketLabel(bracket) {
+	if (bracket.first === bracket.last) { // top brackets aren't really a range
+		return bracket.first;
+	}
+	if (bracket.last === -1) { // last rank is any score above
+		return `${bracket.first} and above`
+	}
+
+	return `${bracket.first} - ${bracket.last}`;
+}
+
+function RankedRewardsTab({eventData}) {
+	const {ranked_brackets} = eventData;
+
+	return (
+		<Table celled striped compact='very'>
+			<Table.Body>
+				{ranked_brackets.map(row => (
+					<Table.Row key={`bracket_${row.first}_${row.last}`}>
+						<Table.Cell width={2}>{getBracketLabel(row)}</Table.Cell>
+						<Table.Cell width={14}>
+							{row.rewards.map(reward => (
+								<Label key={`reward_${reward.id}`} color="black">
+									<Image
+										src={getIconPath(reward.icon)}
+										size="small"
+										inline
+										spaced="right"
+										bordered
+										style={{
+											borderColor: getRarityColor(reward.rarity ?? 0),
+											maxWidth: '27px',
+											maxHeight: '27px'
+										}}
+										alt={reward.full_name}
+									/>
+									{reward.full_name}
+									{reward.quantity > 1 ? ` x ${reward.quantity}` : ''}
+								</Label>
+							))}
+						</Table.Cell>
+					</Table.Row>
+				))}
+			</Table.Body>
+		</Table>
+	);}
+
+export default RankedRewardsTab;

--- a/src/components/event_info_tabs/threshold_rewards.tsx
+++ b/src/components/event_info_tabs/threshold_rewards.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Table, Image, Label } from 'semantic-ui-react';
+
+import { getIconPath, getRarityColor } from '../../utils/assets';
+
+function ThresholdRewardsTab({eventData}) {
+	const {threshold_rewards} = eventData;
+
+	return (
+		<Table celled striped compact='very'>
+			<Table.Body>
+				{threshold_rewards.map(row => (
+					<Table.Row key={row.points}>
+						<Table.Cell>{row.points}</Table.Cell>
+						<Table.Cell>
+							{row.rewards.map(reward => (
+								<Label key={`reward_${reward.id}`} color="black">
+									<Image
+										src={getIconPath(reward.icon)}
+										size="small"
+										inline
+										spaced="right"
+										bordered
+										style={{
+											borderColor: getRarityColor(reward.rarity),
+											maxWidth: '27px',
+											maxHeight: '27px'
+										}}
+										alt={reward.full_name}
+									/>
+									{reward.full_name}
+									{reward.quantity > 1 ? ` x ${reward.quantity}` : ''}
+								</Label>
+							))}
+						</Table.Cell>
+					</Table.Row>
+				))}
+			</Table.Body>
+		</Table>
+	);
+}
+
+export default ThresholdRewardsTab;

--- a/src/components/lazyimage.tsx
+++ b/src/components/lazyimage.tsx
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import { Visibility, Image, Loader, ImageProps } from 'semantic-ui-react'
+
+type LazyImageState = {
+    show: boolean,
+}
+
+class LazyImage extends Component<ImageProps, LazyImageState> {
+    static defaultProps = {
+        size: `medium`,
+    }
+
+    state = {
+        show: false,
+    }
+
+    showImage = () => {
+        this.setState({
+            show: true,
+        })
+    }
+
+    render() {
+        const { size } = this.props
+        if (!this.state.show) {
+            return (
+                <Visibility as="span" fireOnMount onTopVisible={this.showImage}>
+                    <Loader active inline="centered" size={size} />
+                </Visibility>
+            )
+        }
+        return <Image {...this.props} />
+    }
+}
+
+export default LazyImage;

--- a/src/components/topmenu.tsx
+++ b/src/components/topmenu.tsx
@@ -105,6 +105,7 @@ const useMainMenuItems = (verticalLayout: boolean) => {
 	);
 
 	const pages = [
+		{ title: 'Events', link: '/events' },
 		{ title: 'Collections', link: '/collections' },
 		{ title: 'Items', link: '/items' },
 		{ title: 'Misc stats', link: '/stats' },
@@ -112,7 +113,7 @@ const useMainMenuItems = (verticalLayout: boolean) => {
 		{ title: 'Hall of Fame', link: '/hall_of_fame' }
 	];
 	items.push(createSubMenu('Pages', pages));
-	
+
 	items.push(<Menu.Item key='bigbook' onClick={() => navigate('https://bigbook.app')}>Big book</Menu.Item>);
 
 	const about = [

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Container, Header, Message, Segment, Label, Grid, Modal } from 'semantic-ui-react';
+
+import Layout from '../components/layout';
+import LazyImage from '../components/lazyimage';
+import EventInfoModal from '../components/event_info_modal';
+
+type EventInstance = {
+	event_details?: boolean,
+	event_id: number,
+	event_name: string,
+	fixed_instance_id: number,
+	image: string,
+	instance_id: number,
+}
+
+function EventsPage() {
+	const [eventsData, setEventsData] = React.useState<EventInstance[]>([]);
+	const [leaderboardData, setLeaderboardData] = React.useState(null);
+	const [loadingError, setLoadingError] = React.useState(null);
+	const [modalEventInstance, setModalEventInstance] = React.useState(null);
+
+	// load the events and leaderboard data once on component mount
+	React.useEffect(() => {
+		async function loadData() {
+			try {
+				const fetchEventResp = await fetch('/structured/event_instances.json')
+				const eventDataList = await fetchEventResp.json();
+				setEventsData(eventDataList.reverse());
+
+				const fetchLeaderboardResp = await fetch('/structured/event_leaderboards.json');
+				const leaderboardDataList = await fetchLeaderboardResp.json();
+				const keyedLeaderboard = {};
+				leaderboardDataList.forEach(entry => keyedLeaderboard[entry.instance_id] = entry);
+				setLeaderboardData(keyedLeaderboard);
+			}
+			catch (e) {
+				setLoadingError(e);
+			}
+		}
+
+		loadData();
+	}, []);
+
+	return (
+		<Layout>
+			<Container style={{ paddingTop: '4em', paddingBottom: '2em' }}>
+				<Header as='h2'>Events</Header>
+				{loadingError && (
+					<Message negative>
+						<Message.Header>Unable to load event information</Message.Header>
+						<pre>{loadingError.toString()}</pre>
+					</Message>
+				)}
+				<Grid stackable columns={3}>
+					{eventsData.map(eventInfo => (
+						<Grid.Column key={eventInfo.instance_id}>
+							<div
+								style={{ cursor: 'pointer' }}
+								onClick={() => setModalEventInstance(eventInfo)}
+							>
+								<Segment padded>
+									<Label attached="bottom">
+										{eventInfo.event_name}
+									</Label>
+									<LazyImage
+										src={`${process.env.GATSBY_ASSETS_URL}${eventInfo.image}`}
+										size="large"
+										onError={e => e.target.style.visibility = 'hidden'}
+									/>
+								</Segment>
+							</div>
+						</Grid.Column>
+					))}
+				</Grid>
+				{modalEventInstance !== null && (
+					<Modal
+						open
+						size="large"
+						onClose={() => setModalEventInstance(null)}
+						closeIcon
+					>
+						<Modal.Header>{modalEventInstance.event_name}</Modal.Header>
+						<Modal.Content scrolling>
+							<EventInfoModal
+								instanceId={modalEventInstance.instance_id}
+								image={modalEventInstance.image}
+								hasDetails={modalEventInstance.event_details}
+								leaderboard={leaderboardData[modalEventInstance.instance_id].leaderboard}
+							/>
+						</Modal.Content>
+					</Modal>
+				)}
+			</Container>
+		</Layout>
+	);
+}
+
+export default EventsPage;

--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -1,0 +1,27 @@
+import CONFIG from '../components/CONFIG';
+
+type IconObject = {
+    file: string,
+    atlas_info?: string,
+}
+
+export function getIconPath(icon: IconObject) {
+    let file = icon.file
+        .replace(/^\//, '') // remove leading slash if present
+        .replace(/\//g, '_') // convert all slashes to underscores
+        .replace(/\.png$/, ''); // remove extension if present
+    file += '.png'; // add the extension
+
+    // some objects have an atlas info. not sure if this value matters,
+    //  but we have to prepend the file to find the image.
+    if (icon.atlas_info) {
+        file = `atlas/${file}`;
+    }
+
+    // asset host specified in the env
+    return `${process.env.GATSBY_ASSETS_URL}${file}`;
+}
+
+export function getRarityColor(rarity: number) {
+    return CONFIG.RARITIES[rarity].color;
+}


### PR DESCRIPTION
Fixes #6 

I started this branch about 2 years ago, and wanted to finally submit it.

I tried to make it mobile friendly (stackable grids, lazy loaded images). The only exception that I've found is the tab bar in the modal which doesn't wrap for some reason.

Screenshots:

Added an 'Events' link to the Pages dropdown in the menu and the Events page itself
![Screenshot 2022-04-16 212128](https://user-images.githubusercontent.com/852683/163696395-bf40ebdf-b9fb-439f-a136-f09c7ebb17aa.png)

Event information modal shows event name and event art. It's scrollable, so all the info is below the image
![Screenshot 2022-04-16 212208](https://user-images.githubusercontent.com/852683/163696394-075fc8bd-b95f-49ee-a035-4e625522b90b.png)

Event details tab shows event name, type, featured crew and bonus crew
![Screenshot 2022-04-16 212246](https://user-images.githubusercontent.com/852683/163696393-78f0ead9-f392-4e9e-9f1d-1614e7538784.png)

Threshold rewards tab
![Screenshot 2022-04-16 212304](https://user-images.githubusercontent.com/852683/163696392-4db1cd63-7ab8-4e02-8730-8721444db642.png)

Ranked rewards tab
![Screenshot 2022-04-16 212320](https://user-images.githubusercontent.com/852683/163696391-e0bd8ba7-e0c8-4f17-bdf7-76ede6c107f1.png)

Leaderboard tab
![Screenshot 2022-04-16 212351](https://user-images.githubusercontent.com/852683/163696390-f34c9048-862e-408f-9519-ff9ee3fc5bd3.png)
