### PR TITLE
fixed citation cost lookup config

### DIFF
--- a/src/components/CONFIG.ts
+++ b/src/components/CONFIG.ts
@@ -126,5 +126,5 @@ export default class CONFIG {
 		"medical_officer"
 	]
 
-	static readonly CITATION_COST = [500, 500, 500, 4500, 18000, 50000];
+	static readonly CITATION_COST = [0, 500, 4500, 18000, 50000];
 }


### PR DESCRIPTION
fixes #13 

The lookups in this config were using 0-based indexes for rarity (eg `max_rarity - 1`) and the config had 6 items in it when there are only 5 rarities. This was messing up the costs for citations on the stats page as everything was showing as costing less than it should have. Also, citations for common crew don't exist, so made that cost 0.

Sadly, this raises the time estimate for accruing enough honor significantly...

I searched the codebase to find any other usages of this config and found none outside of charts&stats. 