### PR TITLE
Sets dates for Badgey, Leader Pav

### DIFF
--- a/static/crew/badgey_crew.md
+++ b/static/crew/badgey_crew.md
@@ -6,7 +6,7 @@ memory_alpha: ''
 bigbook_tier:
 events:
 in_portal:
-date:
+date: 26/04/2022
 obtained:
 mega:
 published: false

--- a/static/crew/dsc_pav_leader_crew.md
+++ b/static/crew/dsc_pav_leader_crew.md
@@ -6,7 +6,7 @@ memory_alpha: ''
 bigbook_tier:
 events:
 in_portal:
-date:
+date: 24/03/2022
 obtained:
 mega:
 published: false


### PR DESCRIPTION
This manually sets the dates added for Badgey and Leader Pav in their respective markdowns. The dates used here are from the official announcement and the wiki, respectively. We normally get the dates from BBOBA, but BBOBA does not currently provide any info for 1*, 2*, or 3* crew. The changes made to the markdowns here will only get overwritten if BBOBA adds info for Badgey and Leader Pav, so this shouldn't be a concern because we can expect BBOBA to include the proper dates if that does happen.

This *should* fix the issue of Badgey and Leader Pav always being shown at the top of the crew table when sorting by `date_added`. The `precalculate` script will import dates directly from crew markdowns every time it's run.

Note 1: We might have to do something similar the next time the game adds a 1*, 2*, or 3* crew; OR we can try to catch a missing date when a crew markdown is first created in `parseallcrew` (`refreshMarkdown`).

Note 2: This does NOT manually set the series for Badgey. If we set the series for Badgey, we would also need to set the series for Titan Boimler and Batt'leth Mariner for consistency, as all these crew were added before `parseallcrew` was ready for Lower Decks. But as far as I can tell, the series tag isn't ever directly imported from crew markdowns anyway; each crew gets their series set in `parseallcrew` using actual game data.