### PR TITLE
Show ship abilities on crew player tool

### DIFF
--- a/src/components/profile_crew.tsx
+++ b/src/components/profile_crew.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Table, Icon, Rating, Form, Checkbox, Header } from 'semantic-ui-react';
+import { Table, Icon, Rating, Form, Checkbox, Header, Button, Dropdown } from 'semantic-ui-react';
 import { Link, navigate } from 'gatsby';
 
 import { SearchableTable, ITableConfigRow, initSearchableOptions, initCustomOption } from '../components/searchabletable';
 
 import CONFIG from '../components/CONFIG';
+
 import CABExplanation from '../components/cabexplanation';
 import ProspectPicker from '../components/prospectpicker';
 
@@ -69,8 +70,29 @@ type ProfileCrewTools = {
 const ProfileCrewTools = (props: ProfileCrewTools) => {
 	const { allCrew, buffConfig, initOptions } = props;
 	const [prospects, setProspects] = useStateWithStorage('crewTool/prospects', []);
+	const [activeCrew, setActiveCrew] = useStateWithStorage('tools/activeCrew', undefined);
 
 	const myCrew = [...props.myCrew];
+
+	// Create fake ids for active crew based on rarity, level, and equipped status
+	const activeCrewIds = activeCrew.map(ac => {
+		return {
+			id: ac.symbol+','+ac.rarity+','+ac.level+','+ac.equipment.join(''),
+			active_status: ac.active_status
+		};
+	});
+	myCrew.forEach((crew, crewId) => {
+		crew.active_status = 0;
+		if (crew.immortal === 0) {
+			const activeCrewId = crew.symbol+','+crew.rarity+','+crew.level+','+crew.equipment.join('');
+			const active = activeCrewIds.find(ac => ac.id === activeCrewId);
+			if (active) {
+				crew.active_status = active.active_status;
+				active.id = '';	// Clear this id so that dupes are counted properly
+			}
+		}
+	});
+
 	const lockable = [];
 
 	React.useEffect(() => {
@@ -161,37 +183,82 @@ type ProfileCrewTableProps = {
 
 const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 	const pageId = props.pageId ?? 'crew';
-	const [showFrozen, setShowFrozen] = useStateWithStorage(pageId+'/showFrozen', true);
+	const [tableView, setTableView] = useStateWithStorage(pageId+'/tableView', 'base');
 	const [findDupes, setFindDupes] = useStateWithStorage(pageId+'/findDupes', false);
+	const [statusFilter, setStatusFilter] = useStateWithStorage(pageId+'/statusFilter', '');
+	const [rarityFilter, setRarityFilter] = useStateWithStorage(pageId+'/rarityFilter', []);
+
+	const statusFilterOptions = [
+		{ key: 'none', value: '', text: 'Show all crew' },
+		{ key: 'unfrozen', value: 'unfrozen', text: 'Only show unfrozen crew' },
+		{ key: 'frozen', value: 'frozen', text: 'Only show frozen crew' }
+	];
+	if (pageId === 'crewTool') statusFilterOptions.push(
+		{ key: 'available', value: 'available', text: 'Only show available crew' }
+	);
+
+	const rarityFilterOptions = [
+		{ key: '1*', value: 1, text: '1* Common' },
+		{ key: '2*', value: 2, text: '2* Uncommon' },
+		{ key: '3*', value: 3, text: '3* Rare' },
+		{ key: '4*', value: 4, text: '4* Super Rare' },
+		{ key: '5*', value: 5, text: '5* Legendary' }
+	];
 
 	const myCrew = JSON.parse(JSON.stringify(props.crew));
+	myCrew.forEach(crew => {
+		if (!crew.action.ability) crew.action.ability = { type: '', condition: '' };
+	});
 
 	const tableConfig: ITableConfigRow[] = [
 		{ width: 3, column: 'name', title: 'Crew', pseudocolumns: ['name', 'events', 'collections.length'] },
 		{ width: 1, column: 'max_rarity', title: 'Rarity', reverse: true, tiebreakers: ['rarity'] },
-		{ width: 1, column: 'bigbook_tier', title: 'Tier' },
-		{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
-		{ width: 1, column: 'ranks.voyRank', title: 'Voyage' }
 	];
-	CONFIG.SKILLS_SHORT.forEach((skill) => {
-		tableConfig.push({
-			width: 1,
-			column: `${skill.name}.core`,
-			title: <img alt={CONFIG.SKILLS[skill.name]} src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${skill.name}.png`} style={{ height: '1.1em' }} />,
-			reverse: true
+
+	if (tableView === 'base') {
+		tableConfig.push(
+			{ width: 1, column: 'bigbook_tier', title: 'Tier' },
+			{ width: 1, column: 'cab_ov', title: <span>CAB <CABExplanation /></span>, reverse: true, tiebreakers: ['cab_ov_rank'] },
+			{ width: 1, column: 'ranks.voyRank', title: 'Voyage' }
+		);
+		CONFIG.SKILLS_SHORT.forEach((skill) => {
+			tableConfig.push({
+				width: 1,
+				column: `${skill.name}.core`,
+				title: <img alt={CONFIG.SKILLS[skill.name]} src={`${process.env.GATSBY_ASSETS_URL}atlas/icon_${skill.name}.png`} style={{ height: '1.1em' }} />,
+				reverse: true
+			});
 		});
-	});
+	}
+
+	if (tableView === 'ship') {
+		tableConfig.push(
+			{ width: 1, column: 'action.bonus_type', title: 'Boosts' },
+			{ width: 1, column: 'action.bonus_amount', title: 'Amount', reverse: true },
+			{ width: 1, column: 'action.penalty.type', title: 'Handicap' },
+			{ width: 1, column: 'action.initial_cooldown', title: 'Initialize' },
+			{ width: 1, column: 'action.cooldown', title: 'Cooldown' },
+			{ width: 1, column: 'action.duration', title: 'Duration', reverse: true },
+			{ width: 1, column: 'action.limit', title: 'Uses' },
+			{ width: 1, column: 'action.ability.type', title: 'Bonus Ability' },
+			{ width: 1, column: 'action.ability.condition', title: 'Trigger', tiebreakers: ['action.ability.type'] },
+			{ width: 1, column: 'ship_battle.accuracy', title: 'Accuracy', reverse: true },
+			{ width: 1, column: 'ship_battle.crit_bonus', title: 'Crit Bonus', reverse: true },
+			{ width: 1, column: 'ship_battle.crit_chance', title: 'Crit Rating', reverse: true },
+			{ width: 1, column: 'ship_battle.evasion', title: 'Evasion', reverse: true }
+		);
+	}
 
 	function showThisCrew(crew: any, filters: [], filterType: string): boolean {
-		if (!showFrozen && crew.immortal > 0) {
-			return false;
-		}
-
 		if (findDupes) {
 			if (myCrew.filter((c) => c.symbol === crew.symbol).length === 1)
 				return false;
 		}
 
+		if (statusFilter === 'available' && (crew.immortal > 0 || crew.active_status > 0)) return false;
+		if (statusFilter === 'unfrozen' && crew.immortal > 0) return false;
+		if (statusFilter === 'frozen' && crew.immortal === 0) return false;
+		if (rarityFilter.length > 0 && !rarityFilter.includes(crew.max_rarity)) return false;
 		return crewMatchesSearchFilter(crew, filters, filterType);
 	}
 
@@ -221,16 +288,25 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 					</div>
 				</Table.Cell>
 				<Table.Cell>
-					<Rating icon='star' rating={crew.rarity} maxRating={crew.max_rarity} size="large" disabled />
+					<Rating icon='star' rating={crew.rarity} maxRating={crew.max_rarity} size='large' disabled />
 				</Table.Cell>
-				<Table.Cell textAlign="center">
+				{tableView === 'base' && renderBaseNumbers(crew)}
+				{tableView === 'ship' && renderShipNumbers(crew)}
+			</Table.Row>
+		);
+	}
+
+	function renderBaseNumbers(crew: any): JSX.Element {
+		return (
+			<React.Fragment>
+				<Table.Cell textAlign='center'>
 					<b>{formatTierLabel(crew.bigbook_tier)}</b>
 				</Table.Cell>
-				<Table.Cell style={{ textAlign: 'center' }}>
+				<Table.Cell textAlign='center'>
 					<b>{crew.cab_ov}</b><br />
 					<small>{rarityLabels[parseInt(crew.max_rarity)-1]} #{crew.cab_ov_rank}</small>
 				</Table.Cell>
-				<Table.Cell style={{ textAlign: 'center' }}>
+				<Table.Cell textAlign='center'>
 					<b>#{crew.ranks.voyRank}</b><br />
 					{crew.ranks.voyTriplet && <small>Triplet #{crew.ranks.voyTriplet.rank}</small>}
 				</Table.Cell>
@@ -245,7 +321,53 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 						<Table.Cell key={skill.name} />
 					)
 				)}
-			</Table.Row>
+			</React.Fragment>
+		);
+	}
+
+	function renderShipNumbers(crew: any): JSX.Element {
+		return (
+			<React.Fragment>
+				<Table.Cell textAlign='center'>
+					<b>{CONFIG.CREW_SHIP_BATTLE_BONUS_TYPE[crew.action.bonus_type]}</b>
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.bonus_amount && <>+<b>{crew.action.bonus_amount}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.penalty && <><b>{CONFIG.CREW_SHIP_BATTLE_BONUS_TYPE[crew.action.penalty.type]}</b> -<b>{crew.action.penalty.amount}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.initial_cooldown >= 0 && <><b>{crew.action.initial_cooldown}</b>s</>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.cooldown >= 0 && <><b>{crew.action.cooldown}</b>s</>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.duration && <><b>{crew.action.duration}</b>s</>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.limit && <><b>{crew.action.limit}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.ability.type !== '' && <><b>{CONFIG.CREW_SHIP_BATTLE_ABILITY_TYPE[crew.action.ability.type].replace('%VAL%', crew.action.ability.amount)}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.action.ability.type !== '' && <>{CONFIG.CREW_SHIP_BATTLE_TRIGGER[crew.action.ability.condition]}</>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.ship_battle.accuracy && <>+<b>{crew.ship_battle.accuracy}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.ship_battle.crit_bonus && <>+<b>{crew.ship_battle.crit_bonus}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.ship_battle.crit_chance && <>+<b>{crew.ship_battle.crit_chance}</b></>}
+				</Table.Cell>
+				<Table.Cell textAlign='center'>
+					{crew.ship_battle.evasion && <>+<b>{crew.ship_battle.evasion}</b></>}
+				</Table.Cell>
+			</React.Fragment>
 		);
 	}
 
@@ -253,7 +375,7 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 		if (crew.immortal) {
 			return (
 				<div>
-					<Icon name="snowflake" /> <span>{crew.immortal} frozen</span>
+					<Icon name='snowflake' /> <span>{crew.immortal} frozen</span>
 				</div>
 			);
 		} else {
@@ -269,8 +391,9 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 
 			return (
 				<div>
-					{crew.favorite && <Icon name="heart" />}
-					{crew.prospect && <Icon name="add user" />}
+					{crew.favorite && <Icon name='heart' />}
+					{crew.prospect && <Icon name='add user' />}
+					{crew.active_status > 0 && <Icon name='space shuttle' />}
 					<span>Level {crew.level}, </span>
 					{formattedCounts}
 				</div>
@@ -280,14 +403,21 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 
 	return (
 		<React.Fragment>
-			<div style={{ margin: '.5em 0' }}>
+			{pageId === 'crewTool' && (
+				<div style={{ margin: '.5em 0' }}>
+					<Button.Group>
+						<Button onClick={() => setTableView('base')} positive={tableView === 'base' ? true : null} size='large'>
+							Base Skills
+						</Button>
+						<Button.Or />
+						<Button onClick={() => setTableView('ship')} positive={tableView === 'ship' ? true : null} size='large'>
+							Ship Abilities
+						</Button>
+					</Button.Group>
+				</div>
+			)}
+			<div style={{ margin: '1em 0' }}>
 				<Form.Group grouped>
-					<Form.Field
-						control={Checkbox}
-						label='Show frozen (vaulted) crew'
-						checked={showFrozen}
-						onChange={(e, { checked }) => setShowFrozen(checked)}
-					/>
 					<Form.Field
 						control={Checkbox}
 						label='Only show duplicate crew'
@@ -295,6 +425,32 @@ const ProfileCrewTable = (props: ProfileCrewTableProps) => {
 						onChange={(e, { checked }) => setFindDupes(checked)}
 					/>
 				</Form.Group>
+			</div>
+			<div style={{ margin: '1em 0' }}>
+				<Form>
+					<Form.Group inline>
+						<Form.Field
+							placeholder='Filter by status'
+							control={Dropdown}
+							clearable
+							selection
+							options={statusFilterOptions}
+							value={statusFilter}
+							onChange={(e, { value }) => setStatusFilter(value)}
+						/>
+						<Form.Field
+							placeholder='Filter by rarity'
+							control={Dropdown}
+							clearable
+							multiple
+							selection
+							options={rarityFilterOptions}
+							value={rarityFilter}
+							onChange={(e, { value }) => setRarityFilter(value)}
+							closeOnChange
+						/>
+					</Form.Group>
+				</Form>
 			</div>
 			<SearchableTable
 				id={`${pageId}/table_`}

--- a/src/utils/crewutils.ts
+++ b/src/utils/crewutils.ts
@@ -341,6 +341,8 @@ export function prepareProfileData(allcrew, playerData, lastModified) {
 			crew.have = true;
 			crew.favorite = owned.favorite;
 			crew.equipment = owned.equipment;
+			if (owned.action) crew.action.bonus_amount = owned.action.bonus_amount;
+			if (owned.ship_battle) crew.ship_battle = owned.ship_battle;
 			applyCrewBuffs(crew, buffConfig);
 			ownedCrew.push(JSON.parse(JSON.stringify(crew)));
 		});

--- a/src/utils/playerutils.ts
+++ b/src/utils/playerutils.ts
@@ -165,7 +165,11 @@ export function stripPlayerData(items: any[], p: any): any {
 			rarity: crew.rarity,
 			equipment: crew.equipment.map(eq => eq[0]),
 			base_skills: crew.base_skills,
-			favorite: crew.favorite
+			favorite: crew.favorite,
+			action: {
+				bonus_amount: crew.action.bonus_amount
+			},
+			ship_battle: crew.ship_battle
 		}));
 
 	let c_stored_immortals = p.player.character.stored_immortals.filter(im => im.quantity === 1).map(im => im.id);


### PR DESCRIPTION
Adds a toggle to the crew player tool that lets users switch between seeing base skills and ship abilities in the searchable table.

Replaces frozen option with a dropdown to filter by status (e.g. all, frozen, unfrozen, available (not on shuttles or voyage)). Active crew are now reflected in the table by a space shuttle icon.

Adds filter by rarity option.

Exporting your profile to a CSV will now use your current ship abilities (by crew rarity, level) rather than their theoretical numbers.

Note: ship abilities and filter by available status will not be available on shared profile pages.

TODO: Add filter by trait dropdown.

TODO: Optimize!