### PR TITLE
Various ship fixes to crew player tool

### DIFF
--- a/src/utils/crewsearch.ts
+++ b/src/utils/crewsearch.ts
@@ -48,6 +48,11 @@ export function crewMatchesSearchFilter(crew: any, filters: [], filterType: stri
 					conditionResult = skillName in crew.base_skills;
 				} else if (condition.keyword === 'in_portal') {
 					conditionResult = condition.value.toLowerCase() === 'true' ? crew.in_portal : !crew.in_portal;
+				} else if (condition.keyword === 'ship') {
+					conditionResult = matchesFilter(CONFIG.CREW_SHIP_BATTLE_BONUS_TYPE[crew.action.bonus_type], condition.value) ||
+						(crew.action.ability.type !== '' &&
+							(matchesFilter(CONFIG.CREW_SHIP_BATTLE_ABILITY_TYPE[crew.action.ability.type], condition.value) ||
+								matchesFilter(CONFIG.CREW_SHIP_BATTLE_TRIGGER[crew.action.ability.condition], condition.value)));
 				}
 				meetsAllConditions = meetsAllConditions && (condition.negated ? !conditionResult : conditionResult);
 			}


### PR DESCRIPTION
Adds charge phases column to the table. Note: this does not reliably sort by charge_phases at the moment; when charge_phases is defined, it's an array.

Allows for primitive searching of some ship abilities in the search box, e.g. `ship:attack` to find crew with attack bonuses, or `ship:repair` to find crew with repair bonus abilities.

Allows for more reliable sorting by boost, handicap, bonus ability, and trigger.

Updates crew description labels to say "Immortalized" instead of showing level, etc. Also uses Label elements (in brown??) to better highlight matching traits.

Shifts some code around to be a bit more efficient, speedier.