### PR TITLE
Improve skill selection rank logic for voyage calculator.

### DIFF
--- a/src/components/voyagestats.tsx
+++ b/src/components/voyagestats.tsx
@@ -212,7 +212,9 @@ export class VoyageStats extends Component<VoyageStatsProps, VoyageStatsState> {
 						&& !usedCrew.includes(c.id)
 				).length + 1;
 				// Prefer seat skill if no scrolling is necessary
-				if (rank < best.rank && (best.skill !== seatSkill || best.rank >= 3)) {
+				const stayWithSeat = best.skill === seatSkill && best.rank <= 3;
+				const switchToSeat = crewSkill === seatSkill && (rank <= 3 || rank === best.rank);
+				if ((rank < best.rank && !stayWithSeat) || switchToSeat) {
 					best.skill = crewSkill;
 					best.rank = rank;
 				}


### PR DESCRIPTION
Currently, the "prefer seat skill" logic in the voyage calculator skill display only works if the new skill is further down the skill list than the seat skill...that is, it will *stay* on the seat skill, but it will never *switch* to the seat skill.  This MR fixes this, and will actively switch to a new skill if it's the seat skill and either has the same rank or a top-three rank.

Examples:
1. If Barry Waddle is your best listed engineer, but your second-best listed security officer, and is assigned to a *security* seat, the current code works: he'll be listed as "SEC 2" (not "ENG 1")
2. If Barry Waddle is your best listed security officer, but your second-best listed engineer, and is assigned to an *engineering* seat, the current code does not work: he's listed as "SEC 1", but would be better listed as "ENG 2"
3. If Barry Waddle is your 8th best listed security officer and also your 8th best listed engineer, and is assigned to a *security* seat, the current code works: he'll be listed as "SEC 8" instead of "ENG 8"
4. If Barry Waddle is your 8th best listed security officer and also your 8th best listed engineer, and is assigned to a *engineering* seat, the current code does not work: he'll still be listed as "SEC 8", but would be better listed as "ENG 8"

This MR fixes cases 2 and 4 to match the existing, correct behavior of cases 1 and 3.