### PR TITLE
Sets dates for 2* Lower Decks crew

### DIFF
--- a/static/crew/boimler_ensign_crew.md
+++ b/static/crew/boimler_ensign_crew.md
@@ -6,7 +6,7 @@ memory_alpha: ''
 bigbook_tier:
 events:
 in_portal:
-date:
+date: 25/08/2022
 obtained:
 mega:
 published: false

--- a/static/crew/mariner_ensign_crew.md
+++ b/static/crew/mariner_ensign_crew.md
@@ -6,7 +6,7 @@ memory_alpha: ''
 bigbook_tier:
 events:
 in_portal:
-date:
+date: 11/08/2022
 obtained:
 mega:
 published: false

--- a/static/crew/rutherford_ensign_crew.md
+++ b/static/crew/rutherford_ensign_crew.md
@@ -6,7 +6,7 @@ memory_alpha: ''
 bigbook_tier:
 events:
 in_portal:
-date:
+date: 04/08/2022
 obtained:
 mega:
 published: false

--- a/static/crew/tendi_ensign_crew.md
+++ b/static/crew/tendi_ensign_crew.md
@@ -6,7 +6,7 @@ memory_alpha: ''
 bigbook_tier:
 events:
 in_portal:
-date:
+date: 18/08/2022
 obtained:
 mega:
 published: false


### PR DESCRIPTION
This manually sets the dates added for Ensigns Boimler, Mariner, Rutherford, and Tendi, introduced in the Lower Decks mega. The dates will take effect when precalculate is next run.

See #373 for earlier notes on dates and 2* crew. Will have to do again in a couple of weeks for new 2* Kevin Mulkahey.