### PR TITLE
Display BB tiers consistently with bigbook.app

### DIFF
--- a/src/components/commoncrewdata.tsx
+++ b/src/components/commoncrewdata.tsx
@@ -154,7 +154,7 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 					<div style={{ textAlign: 'center' }}>
 						<StatLabel title="Voyage rank" value={crew.ranks.voyRank} />
 						<StatLabel title="Gauntlet rank" value={crew.ranks.gauntletRank} />
-						<StatLabel title="Big book tier" value={formatTierLabel(markdownRemark.frontmatter.bigbook_tier)} />
+						<StatLabel title="Big book tier" value={formatTierLabel(crew)} />
 						{markdownRemark.frontmatter.events !== null && (
 							<StatLabel title="Events" value={markdownRemark.frontmatter.events} />
 						)}
@@ -172,7 +172,7 @@ class CommonCrewData extends Component<CommonCrewDataProps> {
 						)}
 						<Statistic>
 							<Statistic.Label>Big Book Tier</Statistic.Label>
-							<Statistic.Value>{formatTierLabel(markdownRemark.frontmatter.bigbook_tier)}</Statistic.Value>
+							<Statistic.Value>{formatTierLabel(crew)}</Statistic.Value>
 						</Statistic>
 						<Statistic>
 							<Statistic.Label>CAB Rating <CABExplanation /></Statistic.Label>

--- a/src/components/crewretrieval.tsx
+++ b/src/components/crewretrieval.tsx
@@ -1027,7 +1027,7 @@ const CrewTable = (props: CrewTableProps) => {
 					<Rating icon='star' rating={crew.highest_owned_rarity} maxRating={crew.max_rarity} size="large" disabled />
 				</Table.Cell>
 				<Table.Cell textAlign="center" style={{ display: activeCrew === crew.symbol ? 'none' : 'table-cell' }}>
-					<b>{formatTierLabel(crew.bigbook_tier)}</b>
+					<b>{formatTierLabel(crew)}</b>
 				</Table.Cell>
 				<Table.Cell textAlign="center" style={{ display: activeCrew === crew.symbol ? 'none' : 'table-cell' }}>
 					<b>{crew.cab_ov}</b><br />

--- a/src/components/crewtables/commoncells.tsx
+++ b/src/components/crewtables/commoncells.tsx
@@ -52,7 +52,7 @@ export const CrewBaseCells = (props: CrewCellProps) => {
 	return (
 		<React.Fragment>
 			<Table.Cell textAlign='center'>
-				<b>{formatTierLabel(crew.bigbook_tier)}</b>
+				<b>{formatTierLabel(crew)}</b>
 			</Table.Cell>
 			<Table.Cell textAlign='center'>
 				<b>{crew.cab_ov}</b><br />

--- a/src/components/eventplanner.tsx
+++ b/src/components/eventplanner.tsx
@@ -9,7 +9,6 @@ import ProspectPicker from '../components/prospectpicker';
 import ShuttleHelper from '../components/shuttlehelper/shuttlehelper';
 
 import { crewMatchesSearchFilter } from '../utils/crewsearch';
-import { formatTierLabel } from '../utils/crewutils';
 import { guessCurrentEvent, getEventData } from '../utils/events';
 import { useStateWithStorage } from '../utils/storage';
 import { calculateBuffConfig } from '../utils/voyageutils';

--- a/src/components/vaultcrew.tsx
+++ b/src/components/vaultcrew.tsx
@@ -34,7 +34,7 @@ function formatCrewStats(crew: any): JSX.Element {
 	}
 	return (
 		<div>
-			<h4>Tier {formatTierLabel(crew.bigbook_tier)} (Legacy)</h4>
+			<h4>Tier {formatTierLabel(crew)}</h4>
 			{skills}
 			<Link to={`/crew/${crew.symbol}/`}>Full details</Link>
 		</div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -140,7 +140,7 @@ class IndexPage extends Component<IndexPageProps, IndexPageState> {
 					<Rating icon='star' rating={crew.max_rarity} maxRating={crew.max_rarity} size='large' disabled />
 				</Table.Cell>
 				<Table.Cell textAlign="center">
-					<b>{formatTierLabel(crew.bigbook_tier)}</b>
+					<b>{formatTierLabel(crew)}</b>
 				</Table.Cell>
 				<Table.Cell style={{ textAlign: 'center' }}>
 					<b>{crew.cab_ov}</b><br />

--- a/src/utils/crewutils.ts
+++ b/src/utils/crewutils.ts
@@ -359,11 +359,12 @@ export function prepareProfileData(allcrew, playerData, lastModified) {
 	playerData.player.character.unOwnedCrew = unOwnedCrew;
 }
 
-export function formatTierLabel(tier, short = true) {
-	if (!tier || tier === -1) {
-		if (short) {
-			return 'none';
-		}
+export function formatTierLabel(crew) {
+	if (!crew.in_portal && crew.obtained === "WebStore") {
+		return '$';
 	}
-	return `${tier}`;
+	if (!crew.bigbook_tier || crew.bigbook_tier === -1) {
+		return 'none';
+	}
+	return `${crew.bigbook_tier}`;
 }


### PR DESCRIPTION
bigbook.app displays a $ sign instead of the tier number for all cash-only crew (`obtained=="WebStore"`) that have not yet entered the portal. This pull request aims to make Datacore consistent with bigbook.app. This is just a cosmetic change, the actual tier number is there for sorting purposes and the Big Book API will continue to provide it for this class of crew.  