### PR TITLE
Ignore exclusive crew in variant check

### DIFF
--- a/src/components/extracrewdetails.tsx
+++ b/src/components/extracrewdetails.tsx
@@ -62,8 +62,8 @@ class ExtraCrewDetails extends Component<ExtraCrewDetailsProps, ExtraCrewDetails
 		for (let i = 0; i < this.props.traits_hidden.length; i++) {
 			let trait = this.props.traits_hidden[i];
 			if (!series.includes(trait) && !ignore.includes(trait)) {
-				// Also ignore multishow variant traits, e.g. spock_tos, spock_dsc
-				if (!/_[a-z]{3}$/.test(trait) || !series.includes(trait.substr(-3)))
+				// Also ignore exclusive_ crew, e.g. bridge, collection, fusion, gauntlet, honorhall, voyage
+				if (!/^exclusive_/.test(trait))
 					variantTraits.push(trait);
 			}
 		}


### PR DESCRIPTION
Ignores hidden traits with the `exclusive_` prefix in variant check, specifically: exclusive_bridge, exclusive_collection, exclusive_fusion, exclusive_gauntlet, exclusive_honorhall, exclusive_voyage

Removes multishow test from variant check. No longer needed since those traits were completely removed in the latest in-game trait audit.

Latest trait audit removed many rank hidden traits (e.g. crewman, lieutenant, etc.), but not all (e.g. admiral, ensign), so keep those in the ignore list for now.