### PR TITLE
Use crew skill values from player data

### DIFF
--- a/src/utils/crewutils.ts
+++ b/src/utils/crewutils.ts
@@ -322,7 +322,23 @@ export function prepareProfileData(allcrew, playerData, lastModified) {
 			crew.equipment = owned.equipment;
 			if (owned.action) crew.action.bonus_amount = owned.action.bonus_amount;
 			if (owned.ship_battle) crew.ship_battle = owned.ship_battle;
-			applyCrewBuffs(crew, buffConfig);
+			// Use skills directly from player data when possible
+			if (owned.skills) {
+				for (let skill in CONFIG.SKILLS) {
+					crew[skill] = { core: 0, min: 0, max: 0 };
+				}
+				for (let skill in owned.skills) {
+					crew[skill] = {
+						core: owned.skills[skill].core,
+						min: owned.skills[skill].range_min,
+						max: owned.skills[skill].range_max
+					};
+				}
+			}
+			// Otherwise apply buffs to base_skills
+			else {
+				applyCrewBuffs(crew, buffConfig);
+			}
 			ownedCrew.push(JSON.parse(JSON.stringify(crew)));
 		});
 

--- a/src/utils/playerutils.ts
+++ b/src/utils/playerutils.ts
@@ -165,6 +165,7 @@ export function stripPlayerData(items: any[], p: any): any {
 			rarity: crew.rarity,
 			equipment: crew.equipment.map(eq => eq[0]),
 			base_skills: crew.base_skills,
+			skills: crew.skills,
 			favorite: crew.favorite,
 			action: {
 				bonus_amount: crew.action.bonus_amount


### PR DESCRIPTION
Switch to using crew skill values directly from player data instead of applying the buffs to base_skills.

This will lead to (at least) 2 places where the numbers may be inconsistent:

1) The skill numbers of your immortalized crew will still need to be calculated by DataCore; that data isn't in your player data so there's no other way around this.

2) The skill numbers on your shared profile will still need to be calculated by DataCore; I'm not changing the spec for the uploaded json, so everything here will continue to be based on the unboosted numbers.