### PR TITLE
Known crew solves, alpha rule

### DIFF
--- a/src/components/fleetbossbattles.tsx
+++ b/src/components/fleetbossbattles.tsx
@@ -55,10 +55,9 @@ const ComboPicker = () => {
 	const [activeBoss, setActiveBoss] = React.useState(undefined);
 	const [combo, setCombo] = React.useState(undefined);
 
-	const getBossStatus = (boss) => {
-		const unlockedNodes = boss.combo.nodes.filter(node => node.unlocked_character);
+	const getBossChain = (boss) => {
 		const bossName = allData.bossData.groups.find(group => group.symbol === boss.group).name;
-		return `${bossName}, ${DIFFICULTY_NAME[boss.difficulty_id]}, Chain #${boss.combo.previous_node_counts.length+1} (${unlockedNodes.length}/${boss.combo.nodes.length})`;
+		return `${bossName}, ${DIFFICULTY_NAME[boss.difficulty_id]}, Chain #${boss.combo.previous_node_counts.length+1}`;
 	};
 
 	React.useEffect(() => {
@@ -71,7 +70,7 @@ const ComboPicker = () => {
 				difficultyId: boss.difficulty_id,
 				traits: boss.combo.traits,
 				nodes: boss.combo.nodes,
-				status: getBossStatus(boss)
+				chain: getBossChain(boss)
 			};
 			setCombo({...combo});
 		}
@@ -89,7 +88,7 @@ const ComboPicker = () => {
 					{
 						key: boss.id,
 						value: boss.id,
-						text: getBossStatus(boss)
+						text: `${getBossChain(boss)} (${unlockedNodes.length}/${boss.combo.nodes.length})`
 					}
 				);
 			}

--- a/src/components/fleetbossbattles.tsx
+++ b/src/components/fleetbossbattles.tsx
@@ -55,6 +55,12 @@ const ComboPicker = () => {
 	const [activeBoss, setActiveBoss] = React.useState(undefined);
 	const [combo, setCombo] = React.useState(undefined);
 
+	const getBossStatus = (boss) => {
+		const unlockedNodes = boss.combo.nodes.filter(node => node.unlocked_character);
+		const bossName = allData.bossData.groups.find(group => group.symbol === boss.group).name;
+		return `${bossName}, ${DIFFICULTY_NAME[boss.difficulty_id]}, Chain #${boss.combo.previous_node_counts.length+1} (${unlockedNodes.length}/${boss.combo.nodes.length})`;
+	};
+
 	React.useEffect(() => {
 		if (activeBoss) {
 			const boss = allData.bossData.statuses.find(b => b.id === activeBoss);
@@ -64,7 +70,8 @@ const ComboPicker = () => {
 				source: 'playerdata',
 				difficultyId: boss.difficulty_id,
 				traits: boss.combo.traits,
-				nodes: boss.combo.nodes
+				nodes: boss.combo.nodes,
+				status: getBossStatus(boss)
 			};
 			setCombo({...combo});
 		}
@@ -74,9 +81,6 @@ const ComboPicker = () => {
 		return <Message>No boss data found. Please upload a more recent version of your player data.</Message>;
 
 	const bossOptions = [];
-	const getBossName = (bossSymbol) => {
-		return allData.bossData.groups.find(group => group.symbol === bossSymbol).name;
-	};
 	allData.bossData.statuses.forEach(boss => {
 		if (boss.ends_in) {
 			const unlockedNodes = boss.combo.nodes.filter(node => node.unlocked_character);
@@ -85,7 +89,7 @@ const ComboPicker = () => {
 					{
 						key: boss.id,
 						value: boss.id,
-						text: `${getBossName(boss.group)}, ${DIFFICULTY_NAME[boss.difficulty_id]}, Chain #${boss.combo.previous_node_counts.length+1} (${unlockedNodes.length}/${boss.combo.nodes.length})`
+						text: getBossStatus(boss)
 					}
 				);
 			}
@@ -108,7 +112,7 @@ const ComboPicker = () => {
 				}
 				{bossOptions.length === 0 && <Message>You have no open fleet boss battles.</Message>}
 			</div>
-			{combo && <ComboSolver allCrew={allData.allCrew} combo={combo} />}
+			{combo && <ComboSolver dbid={allData.playerData.player.dbid} allCrew={allData.allCrew} combo={combo} />}
 		</React.Fragment>
 	);
 };

--- a/src/components/fleetbossbattles/combochecklist.tsx
+++ b/src/components/fleetbossbattles/combochecklist.tsx
@@ -25,7 +25,7 @@ const ComboChecklist = (props: ComboChecklistProps) => {
 
 	return (
 		<div style={{ margin: '2em 0' }}>
-			Keep track of crew that have been tried for this combo chain.
+			Keep track of crew who have been tried for this combo chain.
 			<Form.Field
 				placeholder='Search for crew'
 				control={Dropdown}

--- a/src/components/fleetbossbattles/combocrewtable.tsx
+++ b/src/components/fleetbossbattles/combocrewtable.tsx
@@ -115,13 +115,10 @@ const ComboCrewTable = (props) => {
 				<Form>
 					<Form.Group inline>
 						<Form.Field
-							placeholder='Filter by availability'
-							control={Dropdown}
-							clearable
-							selection
-							options={usableFilterOptions}
-							value={usableFilter}
-							onChange={(e, { value }) => setUsableFilter(value)}
+							control={Checkbox}
+							label={<label>Apply alpha rule</label>}
+							checked={enableAlphaRule}
+							onChange={(e, { checked }) => setEnableAlphaRule(checked) }
 						/>
 						<Form.Field
 							control={Checkbox}
@@ -130,10 +127,13 @@ const ComboCrewTable = (props) => {
 							onChange={(e, { checked }) => setShowOptimalsOnly(checked) }
 						/>
 						<Form.Field
-							control={Checkbox}
-							label={<label>Apply alpha rule</label>}
-							checked={enableAlphaRule}
-							onChange={(e, { checked }) => setEnableAlphaRule(checked) }
+							placeholder='Filter by availability'
+							control={Dropdown}
+							clearable
+							selection
+							options={usableFilterOptions}
+							value={usableFilter}
+							onChange={(e, { value }) => setUsableFilter(value)}
 						/>
 					</Form.Group>
 				</Form>
@@ -147,9 +147,10 @@ const ComboCrewTable = (props) => {
 				showFilterOptions={true}
 			/>
 			<div style={{ marginTop: '1em' }}>
+				<p><i>Alpha Rule</i> is a special filter that can rule out crew based on trait names; this unofficial rule has had a high degree of success, but may be removed from the game at any time.</p>
 				<p><i>Optimal Crew</i> are the crew you should try first for efficient use of valor; they exclude crew whose matching traits are a subset of another possible crew for that node.</p>
 				<p><i>Coverage</i> identifies the number of unsolved nodes that a given crew might be the solution for.</p>
-				<p><i>Trait Colors</i> are used to help visualize the rarity of each trait per node (column), e.g. a gold trait means its crew is the only possible crew with that trait in that node, a purple trait is a trait shared by 2 possible crew in that node, a blue trait is shared by 3 possible crew, etc. Trait rarity may be affected by your crew filters.</p>
+				<p><i>Trait Colors</i> are used to help visualize the rarity of each trait per node (column), e.g. a gold trait means its crew is the only possible crew with that trait in that node, a purple trait is a trait shared by 2 possible crew in that node, a blue trait is shared by 3 possible crew, etc. Trait rarity is not responsive to crew availability.</p>
 			</div>
 		</div>
 	);

--- a/src/components/fleetbossbattles/combosolver.tsx
+++ b/src/components/fleetbossbattles/combosolver.tsx
@@ -185,8 +185,24 @@ const ComboSolver = (props: ComboSolverProps) => {
 					removeCrewNodeCombo(crew, ignored.index, ignored.combo);
 			});
 		});
-
 		const validatedCrew = allMatchingCrew.filter(crew => crew.nodes_rarity > 0);
+
+		// Annotate remaining exceptions to alpha rule
+		validatedCrew.forEach(crew => {
+			crew.alpha_rule = { compliant: crew.nodes_rarity, exceptions: [] };
+			Object.values(crew.node_matches).forEach(node => {
+				let combosCompliant = node.combos.length;
+				const alphaTest = openNodes.find(n => n.index === node.index).alphaTest;
+				node.combos.forEach(combo => {
+					if (!combo.every(trait => trait.localeCompare(alphaTest) === 1)) {
+						crew.alpha_rule.exceptions.push({ index: node.index, combo });
+						combosCompliant--;
+					}
+				});
+				if (combosCompliant === 0) crew.alpha_rule.compliant--;
+			});
+		});
+
 		setAllMatchingCrew([...validatedCrew]);
 	}, [traitPool, attemptedCrew]);
 

--- a/src/components/fleetbossbattles/combosolver.tsx
+++ b/src/components/fleetbossbattles/combosolver.tsx
@@ -18,6 +18,7 @@ const MAX_RARITY_BY_DIFFICULTY = {
 };
 
 type ComboSolverProps = {
+	dbid: string;
 	allCrew: string[];
 	combo: any;
 };
@@ -216,7 +217,7 @@ const ComboSolver = (props: ComboSolverProps) => {
 						solveNode={onNodeSolved} markAsTried={onCrewMarked}
 					/>
 					<ComboChecklist comboId={combo.id} crewList={props.allCrew} attemptedCrew={attemptedCrew} updateAttempts={setAttemptedCrew} />
-					<ExportCrewLists openNodes={openNodes} allMatchingCrew={allMatchingCrew} />
+					<ExportCrewLists dbid={props.dbid} combo={combo} openNodes={openNodes} allMatchingCrew={allMatchingCrew} />
 				</React.Fragment>
 			}
 			{(activeStep === 'traits' || openNodes.length === 0) &&

--- a/src/components/fleetbossbattles/combosolver.tsx
+++ b/src/components/fleetbossbattles/combosolver.tsx
@@ -66,11 +66,13 @@ const ComboSolver = (props: ComboSolverProps) => {
 				}
 			});
 			if (nodeIsOpen) {
+				const alphaTest = node.open_traits.sort((a, b) => b.localeCompare(a))[0];
 				openNodes.push({
 					comboId: combo.id,
 					index: nodeIndex,
 					traitsKnown,
-					hiddenLeft
+					hiddenLeft,
+					alphaTest
 				});
 			}
 			if (node.unlocked_crew_archetype_id) {

--- a/src/components/fleetbossbattles/exporter.tsx
+++ b/src/components/fleetbossbattles/exporter.tsx
@@ -76,7 +76,7 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 	const { dbid, combo, openNodes, allMatchingCrew } = props;
 
 	const [showOptimalsOnly, setShowOptimalsOnly] = React.useState(true);
-	const [enableAlphaRule, setEnableAlphaRule] = React.useState(false);
+	const [enableAlphaRule, setEnableAlphaRule] = React.useState(true);
 	const [formattingOptions, setFormattingOptions] = useStateWithStorage(dbid+'/fbb/formatting', formattingDefaults, { rememberForever: true });
 
 	const sortedTraits = (traits) => {
@@ -92,20 +92,18 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 	const copyPossible = () => {
 		let crewList = JSON.parse(JSON.stringify(allMatchingCrew));
 		if (enableAlphaRule) {
-			const finalTraits = [];
-			openNodes.forEach(node => {
-				const finalTrait = node.traitsKnown.sort((a, b) => b.localeCompare(a))[0];
-				finalTraits.push({ index: node.index, trait: finalTrait });
-			});
-			crewList = filterCrewByAlphaRule(crewList, finalTraits);
+			crewList = filterCrewByAlphaRule(crewList, openNodes);
 		}
 		if (showOptimalsOnly) {
 			const optimalCombos = getOptimalCombos(crewList);
 			crewList = crewList.filter(crew => isCrewOptimal(crew, optimalCombos));
 		}
 		let output = '';
-		if (formattingOptions.show_chain === 'always' || formattingOptions.show_chain === 'header')
+		if (formattingOptions.show_chain === 'always') {
 			output += combo.status;
+			if (enableAlphaRule) output += ' alpha';
+			if (showOptimalsOnly) output += ' optimal';
+		}
 		openNodes.forEach(node => {
 			const possibleCombos = [];
 			const crewByNode = crewList.filter(crew => !!crew.node_matches[`node-${node.index}`]);
@@ -245,7 +243,7 @@ const CustomFormatting = (props: CustomFormattingProps) => {
 		return (
 			<div style={{ marginBottom: '2em', padding: '0 1.5em' }}>
 				<div>
-					You can customize the appearance of and the details included in the export. The following settings are saved.
+					You can customize what details are included in the export. The following settings are saved.
 				</div>
 				<Form style={{ marginTop: '1em' }}>
 					<Form.Group>

--- a/src/components/fleetbossbattles/exporter.tsx
+++ b/src/components/fleetbossbattles/exporter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Header, Button, Popup, Message, Accordion, Icon, Form, Select, Checkbox } from 'semantic-ui-react';
 
-import { getOptimalCombos, isCrewOptimal, filterCrewByAlphaRule, getComboIndex } from './fbbutils';
+import { getOptimalCombos, isCrewOptimal, filterAlphaExceptions, getComboIndex } from './fbbutils';
 import { useStateWithStorage } from '../../utils/storage';
 
 import allTraits from '../../../static/structured/translation_en.json';
@@ -62,7 +62,7 @@ export const ExportTraits = (props: ExportTraitsProps) => {
 };
 
 const exportDefaults = {
-	header: 'chain',
+	header: 'always',
 	traits: 'all',
 	bullet: 'simple',
 	delimiter: ',',
@@ -100,11 +100,11 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 
 	const copyPossible = () => {
 		let crewList = JSON.parse(JSON.stringify(allMatchingCrew));
-		if (exportPrefs.alpha === 'hide') crewList = crewList = filterCrewByAlphaRule(crewList, openNodes);
+		if (exportPrefs.alpha === 'hide') crewList = filterAlphaExceptions(crewList);
 		const optimalCombos = getOptimalCombos(crewList);
 		if (exportPrefs.optimal === 'hide') crewList = crewList.filter(crew => isCrewOptimal(crew, optimalCombos));
 		let output = '';
-		if (exportPrefs.header === 'chain') {
+		if (exportPrefs.header === 'always' || (exportPrefs.header === 'initial' && combo.nodes.length-openNodes.length === 0)) {
 			output += `${combo.chain} (${combo.nodes.length-openNodes.length}/${combo.nodes.length})`;
 		}
 		openNodes.forEach(node => {
@@ -203,7 +203,8 @@ const CustomExport = (props: CustomExportProps) => {
 	}, [headerPref, traitsPref, bulletPref, delimiterPref, alphaPref, optimalPref]);
 
 	const headerOptions = [
-		{ key: 'chain', text: 'Show boss chain', value: 'chain' },
+		{ key: 'always', text: 'Always show boss chain', value: 'always' },
+		{ key: 'initial', text: 'Show on new chains only', value: 'initial' },
 		{ key: 'hide', text: 'Do not show', value: 'hide' }
 	];
 
@@ -255,7 +256,7 @@ const CustomExport = (props: CustomExportProps) => {
 		return (
 			<div style={{ marginBottom: '2em', padding: '0 1.5em' }}>
 				<div>
-					You can customize what details are included in the export. All preferences here will be remembered.
+					You can customize the details that are included in the export. All preferences here will be remembered.
 				</div>
 				<Form style={{ marginTop: '1em' }}>
 					<Form.Group grouped>

--- a/src/components/fleetbossbattles/exporter.tsx
+++ b/src/components/fleetbossbattles/exporter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Header, Button, Popup, Message, Form, Checkbox } from 'semantic-ui-react';
 
-import { getOptimalCombos, isCrewOptimal } from './fbbutils';
+import { getOptimalCombos, isCrewOptimal, filterCrewByAlphaRule } from './fbbutils';
 
 import allTraits from '../../../static/structured/translation_en.json';
 
@@ -66,6 +66,7 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 	const { openNodes, allMatchingCrew } = props;
 
 	const [showOptimalsOnly, setShowOptimalsOnly] = React.useState(true);
+	const [enableAlphaRule, setEnableAlphaRule] = React.useState(false);
 	const [showTraits, setShowTraits] = React.useState(true);
 
 	const sortedTraits = (traits) => {
@@ -79,7 +80,15 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 	};
 
 	const copyPossible = () => {
-		let crewList = allMatchingCrew.slice();
+		let crewList = JSON.parse(JSON.stringify(allMatchingCrew));
+		if (enableAlphaRule) {
+			const finalTraits = [];
+			openNodes.forEach(node => {
+				const finalTrait = node.traitsKnown.sort((a, b) => b.localeCompare(a))[0];
+				finalTraits.push({ index: node.index, trait: finalTrait });
+			});
+			crewList = filterCrewByAlphaRule(crewList, finalTraits);
+		}
 		if (showOptimalsOnly) {
 			const optimalCombos = getOptimalCombos(crewList);
 			crewList = crewList.filter(crew => isCrewOptimal(crew, optimalCombos));
@@ -131,6 +140,12 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 							label={<label>Only list optimal crew</label>}
 							checked={showOptimalsOnly}
 							onChange={(e, { checked }) => setShowOptimalsOnly(checked) }
+						/>
+						<Form.Field
+							control={Checkbox}
+							label={<label>Apply alpha rule</label>}
+							checked={enableAlphaRule}
+							onChange={(e, { checked }) => setEnableAlphaRule(checked) }
 						/>
 						<Form.Field
 							control={Checkbox}

--- a/src/components/fleetbossbattles/exporter.tsx
+++ b/src/components/fleetbossbattles/exporter.tsx
@@ -100,9 +100,7 @@ export const ExportCrewLists = (props: ExportCrewListsProps) => {
 		}
 		let output = '';
 		if (formattingOptions.show_chain === 'always') {
-			output += combo.status;
-			if (enableAlphaRule) output += ' alpha';
-			if (showOptimalsOnly) output += ' optimal';
+			output += `${combo.chain} (${combo.nodes.length-openNodes.length}/${combo.nodes.length})`;
 		}
 		openNodes.forEach(node => {
 			const possibleCombos = [];

--- a/src/components/fleetbossbattles/fbbutils.ts
+++ b/src/components/fleetbossbattles/fbbutils.ts
@@ -43,18 +43,18 @@ export function isCrewOptimal(crew: any, optimalCombos: any[]): boolean {
 
 export function filterCrewByAlphaRule(crewList: any[], openNodes: any[]): any[] {
 	return crewList.filter(crew => {
-		const unviableCombos = [];
+		const exceptions = [];
 		Object.values(crew.node_matches).forEach(node => {
 			const open = openNodes.find(n => n.index === node.index);
 			if (open) {
 				const alphaTest = open.alphaTest;
 				node.combos.forEach(combo => {
 					if (!combo.every(trait => trait.localeCompare(alphaTest) === 1))
-						unviableCombos.push({ index: node.index, combo: combo });
+						exceptions.push({ index: node.index, combo: combo });
 				});
 			}
 		});
-		unviableCombos.forEach(combo => {
+		exceptions.forEach(combo => {
 			removeCrewNodeCombo(crew, combo.index, combo.combo);
 		});
 		return crew.nodes_rarity > 0;

--- a/src/components/fleetbossbattles/fbbutils.ts
+++ b/src/components/fleetbossbattles/fbbutils.ts
@@ -41,15 +41,18 @@ export function isCrewOptimal(crew: any, optimalCombos: any[]): boolean {
 	return isOptimal;
 }
 
-export function filterCrewByAlphaRule(crewList: any[], finalTraits: any[]): any[] {
+export function filterCrewByAlphaRule(crewList: any[], openNodes: any[]): any[] {
 	return crewList.filter(crew => {
 		const unviableCombos = [];
 		Object.values(crew.node_matches).forEach(node => {
-			const finalTrait = finalTraits.find(ft => ft.index === node.index).trait;
-			node.combos.forEach(combo => {
-				if (!combo.every(trait => trait.localeCompare(finalTrait) === 1))
-					unviableCombos.push({ index: node.index, combo: combo });
-			});
+			const open = openNodes.find(n => n.index === node.index);
+			if (open) {
+				const alphaTest = open.alphaTest;
+				node.combos.forEach(combo => {
+					if (!combo.every(trait => trait.localeCompare(alphaTest) === 1))
+						unviableCombos.push({ index: node.index, combo: combo });
+				});
+			}
 		});
 		unviableCombos.forEach(combo => {
 			removeCrewNodeCombo(crew, combo.index, combo.combo);

--- a/src/components/fleetbossbattles/fbbutils.ts
+++ b/src/components/fleetbossbattles/fbbutils.ts
@@ -41,20 +41,10 @@ export function isCrewOptimal(crew: any, optimalCombos: any[]): boolean {
 	return isOptimal;
 }
 
-export function filterCrewByAlphaRule(crewList: any[], openNodes: any[]): any[] {
+export function filterAlphaExceptions(crewList: any[]): any[] {
 	return crewList.filter(crew => {
-		const exceptions = [];
-		Object.values(crew.node_matches).forEach(node => {
-			const open = openNodes.find(n => n.index === node.index);
-			if (open) {
-				const alphaTest = open.alphaTest;
-				node.combos.forEach(combo => {
-					if (!combo.every(trait => trait.localeCompare(alphaTest) === 1))
-						exceptions.push({ index: node.index, combo: combo });
-				});
-			}
-		});
-		exceptions.forEach(combo => {
+		if (crew.alpha_rule.compliant === 0) return false;
+		crew.alpha_rule.exceptions.forEach(combo => {
 			removeCrewNodeCombo(crew, combo.index, combo.combo);
 		});
 		return crew.nodes_rarity > 0;


### PR DESCRIPTION
Prepwork for fleet boss battles player tool in anticipation of forthcoming 9.2.0 client update, here specifically addressing some common requests.

Known crew solutions (and their respective combos) are now considered unviable for remaining open nodes.

Adds option to apply alpha rule to crew table and exporter.

Trait rarity (colors) is no longer responsive to availability filter.