### PR TITLE
Correct worker name

### DIFF
--- a/src/components/voyagecalculator/civas.tsx
+++ b/src/components/voyagecalculator/civas.tsx
@@ -71,7 +71,7 @@ const CIVASMessage = (props: CIVASMessageProps) => {
 		};
 		const VoyageEstConfig = {
 			config,
-			worker: 'VoyageEstimate'
+			worker: 'voyageEstimate'
 		};
 		const worker = new UnifiedWorker();
 		worker.addEventListener('message', message => {


### PR DESCRIPTION
I accidentally introduced a single letter bug with the Transwarp update. This fixes it.