### PR TITLE
Remove graphql-typescript-definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "gatsby-source-filesystem": "^3.0.0",
     "gatsby-transformer-json": "^3.0.0",
     "gatsby-transformer-remark": "^5.25.1",
-    "graphql-typescript-definitions": "^0.22.0",
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",
     "lodash.combinations": "^18.10.0",


### PR DESCRIPTION
This library is unused and is the sole reason we are stuck using version 16 of node. Therefore, unless anyone has any knowledge of a higher purpose for it I propose to remove it. 