### PR TITLE
Crew retrieval redesign 

### DIFF
--- a/src/components/retrieval/combos.tsx
+++ b/src/components/retrieval/combos.tsx
@@ -27,7 +27,7 @@ export const CombosModal = (props: CombosModalProps) => {
 	const addedPolestars = polestarTailors.added;
 	const disabledPolestars = polestarTailors.disabled;
 
- 	const [modalIsOpen, setModalIsOpen] = React.useState(false);
+ 	const [modalIsOpen, setModalIsOpen] = React.useState<boolean>(false);
 
 	// Unique combos consider all polestars
 	const [uniqueCombos, setUniqueCombos] = React.useState<IPolestar[][] | undefined>(undefined);
@@ -36,8 +36,8 @@ export const CombosModal = (props: CombosModalProps) => {
 	const [tailoredCombos, setTailoredCombos] = React.useState<IPolestar[][] | undefined>(undefined);
 	const [tailoredFuseGroups, setTailoredFuseGroups] = React.useState<IFuseGroups | undefined>(undefined);
 
-	const [fuseIndex, setFuseIndex] = React.useState(1);
-	const [groupIndex, setGroupIndex] = React.useState(0);
+	const [fuseIndex, setFuseIndex] = React.useState<number>(1);
+	const [groupIndex, setGroupIndex] = React.useState<number>(0);
 
 	const [actionableOnlyMode, setActionableOnlyMode] = React.useState<boolean>(true);
 
@@ -116,7 +116,7 @@ export const CombosModal = (props: CombosModalProps) => {
 			}
 
 			if (tailoredCombos && tailoredFuseGroups) {
-				const fuseOptions = [] as NumericOptions[];
+				const fuseOptions: NumericOptions[] = [];
 				[1, 2, 3, 4, 5].forEach(fuse => {
 					const fuseId = 'x' + fuse;
 					if (tailoredFuseGroups[fuseId] && tailoredFuseGroups[fuseId].length > 0) {
@@ -125,7 +125,7 @@ export const CombosModal = (props: CombosModalProps) => {
 				});
 
 				const groups = tailoredFuseGroups['x'+fuseIndex];
-				let groupOptions = [] as NumericOptions[];
+				let groupOptions: NumericOptions[] = [];
 				if (fuseIndex > 1) {
 					groupOptions = groups.map((group, groupId) => {
 						return { key: groupId, value: groupId, text: 'Option '+(groupId+1) };
@@ -187,7 +187,7 @@ export const CombosModal = (props: CombosModalProps) => {
 			/>
 		);
 
-		function toggleWishlist() {
+		function toggleWishlist(): void {
 			if (onWishlist) {
 				setWishlist([...wishlist.filter(c => c !== crew.symbol)]);
 				return;
@@ -250,9 +250,9 @@ export const CombosModal = (props: CombosModalProps) => {
 	function preCalculateCombos(): void {
 		if (crew.unique_polestar_combos) {
 			const allPolestars = allKeystones.filter(k => k.type === 'keystone') as IPolestar[];
-			const uniques = [] as IPolestar[][];
+			const uniques: IPolestar[][] = [];
 			crew.unique_polestar_combos.forEach(upc => {
-				const combo = [] as IPolestar[];
+				const combo: IPolestar[] = [];
 				upc.forEach(trait => {
 					const polestar = allPolestars.find(polestar => filterTraits(polestar, trait));
 					if (polestar) combo.push(polestar);
@@ -289,10 +289,10 @@ export const CombosModal = (props: CombosModalProps) => {
 	}
 
 	function getCombos(crew: IRosterCrew, polestars: IPolestar[], knownGroups?: number): [number, IPolestar[][]] {
-		let combos = [] as IPolestar[][];
+		const combos: IPolestar[][] = [];
 		crew.unique_polestar_combos?.forEach(upc => {
 			if (upc.every(trait => polestars.some(polestar => filterTraits(polestar, trait)))) {
-				const combo = [] as IPolestar[];
+				const combo: IPolestar[] = [];
 				upc.forEach(trait => {
 					const polestar = polestars.find(polestar => filterTraits(polestar, trait));
 					if (polestar) combo.push(polestar);

--- a/src/components/retrieval/combosgrid.tsx
+++ b/src/components/retrieval/combosgrid.tsx
@@ -21,9 +21,9 @@ export const CombosGrid = (props: CombosGridProps) => {
 	const addedPolestars = polestarTailors.added;
 	const disabledPolestars = polestarTailors.disabled;
 
-	const [paginationPage, setPaginationPage] = React.useState(1);
+	const [paginationPage, setPaginationPage] = React.useState<number>(1);
 
-	let data = combos.slice().sort(sortCombos);
+	const data: IPolestar[][] = combos.slice().sort(sortCombos);
 
 	// Pagination
 	const itemsPerPage = 10, itemsToShow = itemsPerPage*paginationPage;
@@ -93,9 +93,7 @@ export const CombosGrid = (props: CombosGridProps) => {
 	}
 
 	function renderCount(polestar: IPolestar): JSX.Element {
-		type LabelColor = SemanticCOLORS | undefined;
-
-		let color: LabelColor = undefined;
+		let color: SemanticCOLORS | undefined = undefined;
 
 		if (disabledPolestars.includes(polestar.id))
 			color = 'orange';

--- a/src/components/retrieval/combosplanner.tsx
+++ b/src/components/retrieval/combosplanner.tsx
@@ -32,6 +32,9 @@ export const CombosPlanner = (props: CombosPlannerProps) => {
 		}
 	});
 
+	if (usefulAloneIds.length === 0 && usefulOtherIds.length === 0)
+		return <></>;
+
 	return (
 		<React.Fragment>
 			Unlock retrieval options for this crew by acquiring 1 or more <Label color='yellow'>needed polestars</Label>

--- a/src/components/retrieval/combosplanner.tsx
+++ b/src/components/retrieval/combosplanner.tsx
@@ -12,15 +12,15 @@ type CombosPlannerProps = {
 export const CombosPlanner = (props: CombosPlannerProps) => {
 	const { uniqueCombos } = props;
 
-	const neededIdSets = [] as number[][];
+	const neededIdSets: number[][] = [];
 	uniqueCombos.forEach(combo => {
 		const neededIds = combo.filter(polestar => polestar.owned === 0).map(polestar => polestar.id);
 		if (!neededIdSets.find(ns => ns.length === neededIds.length && ns.every(neededId => neededIds.includes(neededId))))
 		neededIdSets.push(neededIds);
 	});
 
-	const usefulAloneIds = neededIdSets.filter(ns => ns.length === 1).map(ns => ns[0]);
-	const usefulOtherIds = [] as number[];
+	const usefulAloneIds: number[] = neededIdSets.filter(ns => ns.length === 1).map(ns => ns[0]);
+	const usefulOtherIds: number[] = [];
 	neededIdSets.forEach(ns => {
 		if (ns.length > 1) {
 			if (ns.every(neededId => !usefulAloneIds.includes(neededId))) {

--- a/src/components/retrieval/constellations.tsx
+++ b/src/components/retrieval/constellations.tsx
@@ -37,7 +37,7 @@ export const ConstellationPolestars = (props: ConstellationPolestarsProps) => {
 					))}
 				</Label.Group>
 			</div>
-			{constellation.owned > 1 && (<p>You own {constellation.owned} of this constellation.</p>)}
+			{constellation.owned > 1 && <p>You own {constellation.owned} of this constellation.</p>}
 		</div>
 	);
 };
@@ -53,7 +53,7 @@ export const PolestarConstellations = (props: PolestarConstellationsProps) => {
 	const { allKeystones } = React.useContext(RetrievalContext);
 	const { polestar, setActiveConstellation, setActivePolestar } = props;
 
-	const constellations = [] as IConstellation[];
+	const constellations: IConstellation[] = [];
 
 	const ownedConstellations = allKeystones.filter(k => k.type !== 'keystone' && k.owned > 0) as IConstellation[];
 	ownedConstellations.filter(k => k.keystones.includes(polestar.id))

--- a/src/components/retrieval/crew.tsx
+++ b/src/components/retrieval/crew.tsx
@@ -42,47 +42,42 @@ export const RetrievalCrew = () => {
 
 	// Apply crew filters here
 	React.useEffect(() => {
-		if (rosterCrew) {
-			const filtered = rosterCrew.filter(c =>
-				retrievableFilter === '' ||
-				(retrievableFilter === 'retrievable' && c.retrievable === RetrievableState.Viable) ||
-				(retrievableFilter === 'actionable' &&
-					(c.actionable === ActionableState.Now || c.actionable === ActionableState.PostTailor))
-			).filter(c =>
-				ownedFilter === '' ||
-				(ownedFilter === 'owned' && c.highest_owned_rarity > 0) ||
-				(ownedFilter === 'unowned' && c.highest_owned_rarity === 0) ||
-				(ownedFilter === 'wishlist' && wishlist.includes(c.symbol))
-			).filter(c =>
-				ownedFilter === 'unowned' ||
-					!hideFullyFused ||
-					c.highest_owned_rarity < c.max_rarity
-			).filter(c =>
-				rarityFilter.length === 0 ||
-					rarityFilter.includes(c.max_rarity)
-			).filter(c => {
-				if (traitFilter.length === 0) return true;
-				if (minTraitMatches >= traitFilter.length)
-					return traitFilter.every(trait => c.traits.includes(trait));
-				else if (minTraitMatches === 2) {
-					let matches = 0;
-					traitFilter.forEach(trait => {
-						if (c.traits.includes(trait)) matches++;
-					});
-					return matches >= 2;
-				}
-				return traitFilter.some(trait => c.traits.includes(trait));
-			}).filter(c => {
-				if (collectionFilter === '') return true;
-				const collection = collections.find(collection => collection.name === collectionFilter);
-				return collection?.crew?.includes(c.symbol);
-			});
-			setFilteredCrew([...filtered]);
-		}
+		const filtered = rosterCrew.filter(c =>
+			retrievableFilter === '' ||
+			(retrievableFilter === 'retrievable' && c.retrievable === RetrievableState.Viable) ||
+			(retrievableFilter === 'actionable' &&
+				(c.actionable === ActionableState.Now || c.actionable === ActionableState.PostTailor))
+		).filter(c =>
+			ownedFilter === '' ||
+			(ownedFilter === 'owned' && c.highest_owned_rarity > 0) ||
+			(ownedFilter === 'unowned' && c.highest_owned_rarity === 0) ||
+			(ownedFilter === 'wishlist' && wishlist.includes(c.symbol))
+		).filter(c =>
+			ownedFilter === 'unowned' ||
+				!hideFullyFused ||
+				c.highest_owned_rarity < c.max_rarity
+		).filter(c =>
+			rarityFilter.length === 0 ||
+				rarityFilter.includes(c.max_rarity)
+		).filter(c => {
+			if (traitFilter.length === 0) return true;
+			if (minTraitMatches >= traitFilter.length)
+				return traitFilter.every(trait => c.traits.includes(trait));
+			else if (minTraitMatches === 2) {
+				let matches = 0;
+				traitFilter.forEach(trait => {
+					if (c.traits.includes(trait)) matches++;
+				});
+				return matches >= 2;
+			}
+			return traitFilter.some(trait => c.traits.includes(trait));
+		}).filter(c => {
+			if (collectionFilter === '') return true;
+			const collection = collections.find(collection => collection.name === collectionFilter);
+			return collection?.crew?.includes(c.symbol);
+		});
+		setFilteredCrew([...filtered]);
 	}, [rosterCrew, retrievableFilter, ownedFilter, hideFullyFused, rarityFilter, traitFilter, minTraitMatches, collectionFilter, wishlist]);
-
-	if (rosterCrew.length === 0)
-		return (<div style={{ marginTop: '1em' }}><Icon loading name='spinner' /> Loading...</div>);
 
 	const retrievableFilterOptions = [
 		{ key: 'none', value: '', text: 'Show all crew' },

--- a/src/components/retrieval/crew.tsx
+++ b/src/components/retrieval/crew.tsx
@@ -30,7 +30,7 @@ export const RetrievalCrew = () => {
 	const [isPreparing, setIsPreparing] = React.useState<boolean>(false);
 	const [filteredCrew, setFilteredCrew] = React.useState<IRosterCrew[]>([]);
 
-	// Calculate roster initially (or playerData change), or on polestar tailoring
+	// Calculate roster on updated keystone owned counts (i.e. playerData change) or on polestar tailoring
 	React.useEffect(() => {
 		setIsPreparing(true);
 		calculateRoster().then((rosterCrew: IRosterCrew[]) => {
@@ -82,7 +82,7 @@ export const RetrievalCrew = () => {
 	}, [rosterCrew, retrievableFilter, ownedFilter, hideFullyFused, rarityFilter, traitFilter, minTraitMatches, collectionFilter, wishlist]);
 
 	if (rosterCrew.length === 0)
-		return (<div style={{ margin: '1em' }}><Icon loading name='spinner' /> Loading...</div>);
+		return (<div style={{ marginTop: '1em' }}><Icon loading name='spinner' /> Loading...</div>);
 
 	const retrievableFilterOptions = [
 		{ key: 'none', value: '', text: 'Show all crew' },

--- a/src/components/retrieval/crewtable.tsx
+++ b/src/components/retrieval/crewtable.tsx
@@ -174,13 +174,13 @@ const CollectionsExpanded = (props: CollectionsExpandedProps) => {
 		needed: number;
 	};
 
-	const data = crew.progressable_collections.map(collectionName => {
-		const newData = {
+	const data: ICollectionData[] = crew.progressable_collections.map(collectionName => {
+		const newData: ICollectionData = {
 			name: collectionName,
 			progress: 0,
 			goal: 0,
 			needed: 0
-		} as ICollectionData;
+		};
 
 		if (playerData) {
 			const cryoCollection = playerData.player.character.cryo_collections.find(cc => cc.name === collectionName);
@@ -191,7 +191,7 @@ const CollectionsExpanded = (props: CollectionsExpandedProps) => {
 			}
 		}
 		return newData;
-	}) as ICollectionData[];
+	});
 
 	return (
 		<Table.Cell colSpan={6}>

--- a/src/components/retrieval/energy.tsx
+++ b/src/components/retrieval/energy.tsx
@@ -8,10 +8,22 @@ export const RetrievalEnergy = () => {
 
 	if (!playerData) return <></>;
 
-	const energy = playerData.crew_crafting_root.energy;
+	const defaultSeconds = 1800;
+	interface CraftingEnergy {
+		id: number;
+		quantity: number;
+		regenerated_at: number;
+		regeneration?: {
+			increment: number;
+			seconds: number;
+			amount: number;
+		};
+		coupons: number;
+	};
+	const energy: CraftingEnergy = playerData.crew_crafting_root.energy as CraftingEnergy;
 
 	const qTarget = 900;
-	const qPerFullDay = (24*60*60)/(energy.regeneration?.seconds ?? 1); // 48
+	const qPerFullDay = (24*60*60)/(energy.regeneration?.seconds ?? defaultSeconds); // 48
 	const qPerBoost = 50;
 
 	let energyMessage = 'You can guarantee a legendary crew retrieval now!';
@@ -33,7 +45,7 @@ export const RetrievalEnergy = () => {
 	);
 
 	function getSecondsRemaining(target: number, quantity: number): number {
-		return ((target-quantity)*(energy.regeneration.seconds ?? 0))+energy.regenerated_at;
+		return ((target-quantity)*(energy.regeneration?.seconds ?? defaultSeconds))+energy.regenerated_at;
 	}
 
 	function formatTime(seconds: number): string {

--- a/src/components/retrieval/polestarfilter.tsx
+++ b/src/components/retrieval/polestarfilter.tsx
@@ -9,7 +9,7 @@ export const PolestarFilterModal = () => {
 
 	const disabledPolestars = polestarTailors.disabled;
 
-	const [modalIsOpen, setModalIsOpen] = React.useState(false);
+	const [modalIsOpen, setModalIsOpen] = React.useState<boolean>(false);
 	const [pendingDisabled, setPendingDisabled] = React.useState<number[]>([]);
 
 	// Update on external changes, e.g. reset request from crew.tsx
@@ -24,22 +24,28 @@ export const PolestarFilterModal = () => {
 		}
 	}, [modalIsOpen]);
 
-	const rarityIds = [14502, 14504, 14506, 14507, 14509];
-	const skillIds = [14511, 14512, 14513, 14514, 14515, 14516];
-	const grouped = [
+	const rarityIds: number[] = [14502, 14504, 14506, 14507, 14509];
+	const skillIds: number[] = [14511, 14512, 14513, 14514, 14515, 14516];
+
+	interface IPolestarGroup {
+		title: string;
+		polestars: IPolestar[];
+		anyDisabled: boolean;
+	};
+	const grouped: IPolestarGroup[] = [
 		{
 			title: 'Rarity',
-			polestars: [] as IPolestar[],
+			polestars: [],
 			anyDisabled: false
 		},
 		{
 			title: 'Skills',
-			polestars: [] as IPolestar[],
+			polestars: [],
 			anyDisabled: false
 		},
 		{
 			title: 'Traits',
-			polestars: [] as IPolestar[],
+			polestars: [],
 			anyDisabled: false
 		},
 	];
@@ -79,7 +85,7 @@ export const PolestarFilterModal = () => {
 	);
 
 	function createFilterCheckboxes(): JSX.Element[] {
-		const checkboxes = [] as JSX.Element[];
+		const checkboxes: JSX.Element[] = [];
 		grouped.map((group) => {
 			if(group.polestars.length > 0) {
 				checkboxes.push(filterCheckboxGroupHeader(group.title));

--- a/src/components/retrieval/polestarprospects.tsx
+++ b/src/components/retrieval/polestarprospects.tsx
@@ -20,9 +20,9 @@ export const PolestarProspectsModal = () => {
 
 	const addedPolestars = polestarTailors.added;
 
-	const [modalIsOpen, setModalIsOpen] = React.useState(false);
+	const [modalIsOpen, setModalIsOpen] = React.useState<boolean>(false);
 
-	const [crewCrates, setCrewCrates] = React.useState(0);
+	const [crewCrates, setCrewCrates] = React.useState<number>(0);
 	const [ownedConstellations, setOwnedConstellations] = React.useState<IConstellation[]>([]);
 
 	const [activeConstellation, setActiveConstellation] = React.useState<string>('');
@@ -65,7 +65,7 @@ export const PolestarProspectsModal = () => {
 				{renderContent()}
 			</Modal.Content>
 			<Modal.Actions>
-				{activePolestar !== '' && (<Button icon='backward' content='Return to polestars' onClick={() => setActivePolestar('')} />)}
+				{activePolestar !== '' && <Button icon='backward' content='Return to polestars' onClick={() => setActivePolestar('')} />}
 				<Button onClick={() => setModalIsOpen(false)}>Close</Button>
 			</Modal.Actions>
 		</Modal>
@@ -101,7 +101,7 @@ export const PolestarProspectsModal = () => {
 		const allPolestars = allKeystones.filter(k => k.type === 'keystone') as IPolestar[];
 
 		// !! Always filter polestars by crew_count to hide deprecated polestars !!
-		let data = allPolestars.filter(polestar => polestar.crew_count > 0) as IPolestarData[];
+		let data: IPolestarData[] = allPolestars.filter(polestar => polestar.crew_count > 0) as IPolestarData[];
 
 		if (activeConstellation !== '') {
 			const constellation = allKeystones.find(keystone => keystone.symbol === activeConstellation) as IConstellation;
@@ -233,7 +233,7 @@ export const PolestarProspectsModal = () => {
 	}
 
 	function renderPolestarDetail(): JSX.Element {
-		const polestar = allKeystones.find(k => k.symbol === activePolestar) as IPolestarData;
+		const polestar = allKeystones.find(k => k.symbol === activePolestar) as IPolestarData | undefined;
 		if (!polestar) return <></>;
 
 		polestar.loaned = pendingAdded.filter(added => added === polestar.symbol).length;
@@ -332,12 +332,12 @@ type ProspectInventoryProps = {
 const ProspectInventory = (props: ProspectInventoryProps) => {
 	const { polestar, updateProspect } = props;
 
-	const [loaned, setLoaned] = React.useState(props.loaned);
+	const [loaned, setLoaned] = React.useState<number>(props.loaned);
 
 	return (
 		<React.Fragment>
-			{loaned > 0 && (<Button size='mini' circular icon='minus' onClick={(e) => { removeProspect(polestar); e.stopPropagation(); }} />)}
-			{loaned > 0 ? (<span style={{ margin: '0 .5em' }}>{loaned}</span>) : ''}
+			{loaned > 0 && <Button size='mini' circular icon='minus' onClick={(e) => { removeProspect(polestar); e.stopPropagation(); }} />}
+			{loaned > 0 ? <span style={{ margin: '0 .5em' }}>{loaned}</span> : ''}
 			<Button size='mini' circular icon='add' onClick={(e) => { addProspect(polestar); e.stopPropagation(); }} />
 		</React.Fragment>
 	);


### PR DESCRIPTION
Redesigns the crew retrieval tool to better help users identify potentially useful polestars for retrieving crew, in addition to the classic way of showing which crew can be retrieved with currently owned polestars. A new dropdown demonstrates the difference; switch between "Show all uniquely retrievable crew" (new features) and "Only show crew I can retrieve" (classic crew retrieval).

The View Options button in the final column now opens in a modal, which allows for more features, such as a toggle for hiding combos with unowned polestars and suggestions for acquiring needed polestars from owned constellations. (The latter is moved from the prospective polestars modal and prioritized here.)

Polestars use color-coding to help visualize certain situations:
* Yellow = needed polestars
* Orange = filtered polestars
* Blue = added prospective polestars

The combo-fuse generator exclusively uses the short algorithm now. Aside from a couple of instances where it doesn't recognize potential fuses, the short algorithm does exactly what's needed with a quicker response time, so there's no real reason to let users choose the algorithm.

Improves combo sorting, prioritizing combos with more owned polestars. Polestar sorting in combos now matches in-game sort (with skills and rarities listed after traits).

The owned dropdown options has been split into a dropdown with a separate checkbox for hiding fully fused crew.

Switches to the rarity filter component from common options. Adds the trait filter component from common options.

Users can now add crew to a retrieval wishlist (by clicking the heart icon on a crew's combos modal), for help in planning. The owned dropdown includes a filter for showing crew in your wishlist.

Adds gauntlet ranks and quipment grades to the main table.

Collection counts now ignore maxed-out collections when in player mode. Clicking the collection column now expands to a more readable table, with progress shown when in player mode.

Works with and without playerData. When no playerData is present, the user can still apply basic crew filters, but polestar filtering and wishlists won't be available.

Polestar and crew filtering options, plus wishlists, are now set to remember across user sessions, when in player mode.

Refactors the crewretrieval component into several smaller components in `/components/retrieval/`, for easier maintenance.

Minor keystone model audit. All models related to this tool have been commented out in `game-elements` and moved to the local retrieval model.