### PR TITLE
Making factions page sortable

### DIFF
--- a/src/components/factions.tsx
+++ b/src/components/factions.tsx
@@ -4,23 +4,23 @@ import { Faction } from '../model/player';
 import { GlobalContext } from '../context/globalcontext';
 import { IConfigSortData, IResultSortDataBy, sortDataBy } from '../utils/datasort';
 
-const factionImageLocations = [
-  'federation',
-  'klingon',
-  'bajoran',
-  'cardassian',
-  'maquis',
-  'ferengialliance',
-  'ferengitraditionalist',
-  'augments',
-  'romulan',
-  'terran',
-  'klingoncardassian',
-  'section31',
-  'hirogen',
-  'dominion',
-  'borg'
-];
+const factionImageLocations = {
+  12: 'federation',
+  1: 'klingon',
+  8: 'bajoran',
+  4: 'cardassian',
+  5: 'maquis',
+  3: 'ferengialliance',
+  7: 'ferengitraditionalist',
+  2: 'augments',
+  13: 'romulan',
+  11: 'terran',
+  14: 'klingoncardassian',
+  9: 'section31',
+  10: 'hirogen',
+  6: 'dominion',
+  20: 'borg'
+};
 
 const oddsValues = [14].concat(Array.from({length: 9}, (_, i) => (i+3)*5));
 
@@ -203,7 +203,7 @@ class FactionInfo extends PureComponent<ShuttleInfoProps, ShuttleInfoState> {
 
             return (
               <Table.Row key={index}>
-                <Table.Cell><span><Image floated='left' size='mini' src={`${process.env.GATSBY_ASSETS_URL}icons_icon_faction_${factionImageLocations[index]}.png`} />{faction.name}</span></Table.Cell>
+                <Table.Cell><span><Image floated='left' size='mini' src={`${process.env.GATSBY_ASSETS_URL}icons_icon_faction_${factionImageLocations[faction.id]}.png`} />{faction.name}</span></Table.Cell>
                 <Table.Cell>{this._reputations(faction.reputation)}</Table.Cell>
                 <Table.Cell>
                   {faction.reputation < 980 && <p>{shuttlesNeededToMaxRep} successful missions</p>}

--- a/src/components/factions.tsx
+++ b/src/components/factions.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { Table, Image, Dropdown } from 'semantic-ui-react'
 import { Faction } from '../model/player';
 import { GlobalContext } from '../context/globalcontext';
+import { IConfigSortData, IResultSortDataBy, sortDataBy } from '../utils/datasort';
 
 const factionImageLocations = [
   'federation',
@@ -27,19 +28,52 @@ type ShuttleInfoProps =  {
 };
 
 type ShuttleInfoState = {
+  column: string | null;
+  direction?: 'ascending' | 'descending';
+  data: Faction[];
+  originals: Faction[];
   successOdds: number;
+  shuttleBays: number;
 };
 
 class FactionInfo extends PureComponent<ShuttleInfoProps, ShuttleInfoState> {
   static contextType = GlobalContext;
   context!: React.ContextType<typeof GlobalContext>;
+  inited: boolean;
 
   constructor(props) {
     super(props);
 
     this.state = {
-      successOdds: 14
+      column: null,
+      direction: undefined,
+      data: [],
+      originals: [],
+      successOdds: oddsValues[0],
+      shuttleBays: 0
     };
+  }
+
+  componentDidMount() {
+    this.initData();
+  }
+
+  componentDidUpdate(prevProps: Readonly<ShuttleInfoProps>, prevState: Readonly<ShuttleInfoState>, snapshot?: any): void {
+    this.initData();
+  }
+
+  initData() {
+    if (this.inited) return;
+
+    if (!this.context.player.playerData) return;
+    const { factions, shuttle_bays } = this.context.player.playerData.player.character;
+
+    this.inited = true;
+    this.setState({
+      data: factions,
+      originals: factions,
+      shuttleBays: shuttle_bays
+    });
   }
 
   _reputations(score) {
@@ -82,10 +116,41 @@ class FactionInfo extends PureComponent<ShuttleInfoProps, ShuttleInfoState> {
     return (1-odds)*3 - odds*2;
   }
 
+  _nextSort(currentValue) {
+    const values : ('descending' | 'ascending' | undefined)[] = ['ascending', 'descending', undefined];
+    const currentIndex = values.indexOf(currentValue);
+    const nextIndex = (currentIndex + 1) % values.length;
+    return values[nextIndex];
+  }
+
+  _handleSort(clickedColumn, field) {
+    const { column, direction } = this.state;
+    const clickedDirection = this._nextSort(clickedColumn === column ? direction : undefined);
+
+    let data;
+    if (clickedDirection == null) {
+      data = this.state.originals;
+    } else {
+      const sortDirection = clickedColumn.startsWith('-') ?
+        (clickedDirection === "ascending" ? "descending" : "ascending") : clickedDirection;
+
+      data = sortDataBy([...this.state.data], {
+        field: field,
+        direction: sortDirection
+      }).result;
+    }
+
+    this.setState({
+      column: clickedColumn,
+      direction: clickedDirection,
+      data: data
+    });
+  }
+
   render() {
-    if (!this.context.player.playerData) return <></>;
-    const { factions: factionInfo, shuttle_bays: shuttleBays } = this.context.player.playerData.player.character;
-    const { successOdds } = this.state;
+    if (!this.inited) return <></>;
+
+    const { column, direction, data, shuttleBays, successOdds } = this.state;
     const updateSuccessOdds = (odds: number) => this.setState({successOdds: odds});
 
     return (
@@ -96,19 +161,41 @@ class FactionInfo extends PureComponent<ShuttleInfoProps, ShuttleInfoState> {
               {oddsValues.map(val => (<Dropdown.Item onClick={(e, { value }) => updateSuccessOdds(value as number)} text={`${val}%`} value={val} />))}
             </Dropdown.Menu>
           </Dropdown>
-          <p>(Note: Shuttles cannot be run with a probability of success less than 14%. Shuttles need a probability of less than 60% to be tanked.)</p>
         </p>
-        <Table>
+        <p>(Note: Shuttles cannot be run with a probability of success less than 14%. Shuttles need a probability of less than 60% to be tanked.)</p>
+        <Table sortable striped>
           <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>Faction</Table.HeaderCell>
-            <Table.HeaderCell>Reputation</Table.HeaderCell>
-            <Table.HeaderCell>Shuttles needed</Table.HeaderCell>
-            <Table.HeaderCell>Time needed</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={column === 'faction' ? direction : undefined}
+              onClick={() => this._handleSort('faction', 'name')}
+            >
+              Faction
+            </Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={column === 'reputation' ? direction : undefined}
+              onClick={() => this._handleSort('reputation', 'reputation')}
+            >Reputation</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={column === 'honor_shuttles' ? direction : undefined}
+              onClick={() => this._handleSort('honor_shuttles', 'reputation')}
+            >Shuttles to honored</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={column === 'honor_time' ? direction : undefined}
+              onClick={() => this._handleSort('honor_time', 'reputation')}
+            >Time needed</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={column === '-tank_shuttles' ? direction : undefined}
+              onClick={() => this._handleSort('-tank_shuttles', 'completed_shuttle_adventures')}
+            >Shuttles to tank</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={column === '-tank_time' ? direction : undefined}
+              onClick={() => this._handleSort('-tank_time', 'completed_shuttle_adventures')}
+            >Time needed</Table.HeaderCell>
           </Table.Row>
           </Table.Header>
           <Table.Body>
-          {factionInfo.map((faction, index) => {
+          {data.map((faction, index) => {
             let shuttlesNeededToMaxRep = this._shuttlesToHonouredStatus(faction.reputation);
             let hoursNeededToMaxRep = Math.ceil(shuttlesNeededToMaxRep/shuttleBays)*3;
             let shuttlesNeededToTank = Math.ceil(faction.completed_shuttle_adventures/this._expectedCSA(successOdds/100));
@@ -119,13 +206,17 @@ class FactionInfo extends PureComponent<ShuttleInfoProps, ShuttleInfoState> {
                 <Table.Cell><span><Image floated='left' size='mini' src={`${process.env.GATSBY_ASSETS_URL}icons_icon_faction_${factionImageLocations[index]}.png`} />{faction.name}</span></Table.Cell>
                 <Table.Cell>{this._reputations(faction.reputation)}</Table.Cell>
                 <Table.Cell>
-                  {faction.reputation < 980 && <p>You need {shuttlesNeededToMaxRep} successful shuttle missions to achieve honored status.</p>}
-                  {shuttlesNeededToTank > 0 && <p>To tank your shuttles you need to run {shuttlesNeededToTank} shuttles.</p>}
-                  {shuttlesNeededToTank == 0 && <p>Already tanked</p>}
+                  {faction.reputation < 980 && <p>{shuttlesNeededToMaxRep} successful missions</p>}
                 </Table.Cell>
                 <Table.Cell>
                   {faction.reputation < 980 && <p>{this._formatTime(hoursNeededToMaxRep)}</p>}
-                  <p>{this._formatTime(hoursNeededToTank)}</p>
+                </Table.Cell>
+                <Table.Cell>
+                  {shuttlesNeededToTank > 0 && <p>{shuttlesNeededToTank} shuttles to tank</p>}
+                  {shuttlesNeededToTank == 0 && <p>Already tanked</p>}
+                </Table.Cell>
+                <Table.Cell>
+                  {shuttlesNeededToTank > 0 && <p>{this._formatTime(hoursNeededToTank)}</p>}
                 </Table.Cell>
               </Table.Row>
             );


### PR DESCRIPTION
I needed to be able to quickly figure out what faction would be the quickest to tank. Since the page doesn't sort, I made it sort by copying some of the code from the ships page.

Please let me know if there are other changes needed to get this in.

![image](https://github.com/stt-datacore/website/assets/2482238/20a8ee4d-652c-409f-b58f-85086687a29b)
