### PR TITLE
Prevent chain from being modified directly

### DIFF
--- a/src/components/fleetbossbattles/chainsolver.tsx
+++ b/src/components/fleetbossbattles/chainsolver.tsx
@@ -50,7 +50,7 @@ export const ChainSolver = () => {
 			});
 
 			let solveStatus: SolveStatus = SolveStatus.Unsolved;
-			let solve: string[] = node.hidden_traits;
+			let solve: string[] = node.hidden_traits.slice();
 			if (!solve.includes('?')) {
 				solveStatus = SolveStatus.Infallible;
 			}


### PR DESCRIPTION
This fixes the issue where spot solves are considered infallible when solving from traits view.