### PR TITLE
Add pattern for 4-letter month

### DIFF
--- a/src/utils/crewutils.ts
+++ b/src/utils/crewutils.ts
@@ -1068,7 +1068,8 @@ export function getVariantTraits(subject: PlayerCrew | CrewMember | string[]): s
 	];
 	const ignoreRe = [
 		/^exclusive_/,		/* exclusive_ crew, e.g. bridge, collection, fusion, gauntlet, honorhall, voyage */
-		/^[a-z]{3}\d{4}$/	/* mega crew, e.g. feb2023 and apr2023 */
+		/^[a-z]{3}\d{4}$/,	/* mega crew, e.g. feb2023 and apr2023 */
+		/^[a-z]{4}\d{4}$/	/* mega crew, e.g. june2024 and july2024 */
 	];
 	const variantTraits = [] as string[];
 


### PR DESCRIPTION
The system is currently listing all the new mega crew as variants of one-another due to a 'june2024' trait being added. This is too long for the current regex to detect. This new code detect that pattern.