### PR TITLE
Add default value for FBB trait picker

### DIFF
--- a/src/components/fleetbossbattles/traits.tsx
+++ b/src/components/fleetbossbattles/traits.tsx
@@ -139,6 +139,15 @@ const TraitPicker = (props: TraitPickerProps) => {
 			} as TraitOption;
 		}).sort((a, b) => a.text.localeCompare(b.text));
 
+	// Add ? as an option for unsolved nodes
+	if (traitOptions.length > 1) {
+		traitOptions.unshift({
+			key: '?',
+			value: '?',
+			text: '?'
+		});
+	}
+
 	return (
 		<Form.Field>
 			<Dropdown


### PR DESCRIPTION
Adds ? as an option for unsolved nodes in the FBB trait picker in traits view.

This should help the trait picker dropdown behave as expected and correct issues with Chrome, in particular.