### PR TITLE
Fix galaxy helper displays outside of event

### DIFF
--- a/src/components/eventplanner/eventpicker.tsx
+++ b/src/components/eventplanner/eventpicker.tsx
@@ -153,7 +153,7 @@ export const EventPicker = (props: EventPickerProps) => {
 				<React.Fragment>
 					{rosterType === 'myCrew' && <EventProspects pool={bonusCrew} prospects={prospects} setProspects={setProspects} />}
 					{eventData.content_types[phaseIndex] === 'shuttles' && (<EventShuttles crew={rosterCrew} eventData={eventData} />)}
-					{eventData.content_types[phaseIndex] === 'gather' && <GatherPlanner eventSymbol={eventData.symbol} />}
+					{eventData.content_types[phaseIndex] === 'gather' && eventData.seconds_to_start === 0 && eventData.seconds_to_end > 0 &&  <GatherPlanner eventSymbol={eventData.symbol} />}
 				</React.Fragment>
 			)}
 


### PR DESCRIPTION
Gather planner was attempting to display while outside of a galaxy event.  The loading circle kept spinning.  Right now, it should just not show up.  Maybe in the future there could be a general prefarm component.

P.S. please verify logic for determining if event is active.