### PR TITLE
Fix physician/doctor map.

### DIFF
--- a/src/components/items/itemstable.tsx
+++ b/src/components/items/itemstable.tsx
@@ -142,7 +142,8 @@ export function printRequiredTraits(
 	if (item.kwipment) {
 		if (item.traits_requirement?.length) {
 			let req = item.traits_requirement.map((t) =>
-				t === "doctor" ? "physician" : t
+				// t === "doctor" ? "physician" : t
+				t
 			);
 			if (item.traits_requirement_operator === "and") {
 				return (

--- a/src/components/items/itemstable.tsx
+++ b/src/components/items/itemstable.tsx
@@ -141,10 +141,7 @@ export function printRequiredTraits(
 ): JSX.Element {
 	if (item.kwipment) {
 		if (item.traits_requirement?.length) {
-			let req = item.traits_requirement.map((t) =>
-				// t === "doctor" ? "physician" : t
-				t
-			);
+			let req = item.traits_requirement!;
 			if (item.traits_requirement_operator === "and") {
 				return (
 					<Link


### PR DESCRIPTION
Physician trait not displaying correctly on eligible kwipment.  This was due to a change that was made in how trait name were recently localized.