### PR TITLE
Voyage Calc i18n (Pass 2)

### DIFF
--- a/scripts/chktrans.js
+++ b/scripts/chktrans.js
@@ -1,8 +1,4 @@
 const fs = require('fs');
-const showdown = require('showdown');
-const ExcelJS = require('exceljs');
-require('lodash.combinations');
-const _ = require('lodash');
 
 const STATIC_PATH = `${__dirname}/../static/structured/locales`;
 

--- a/scripts/chktrans.js
+++ b/scripts/chktrans.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const showdown = require('showdown');
+const ExcelJS = require('exceljs');
+require('lodash.combinations');
+const _ = require('lodash');
+
+const STATIC_PATH = `${__dirname}/../static/structured/locales`;
+
+const languages = ['en', 'de', 'fr', 'sp'];
+
+function comp(a, b, current) {
+    current ??= "";
+    if (current) current = current + "."
+    let akeys = Object.keys(a);
+    let bkeys = Object.keys(b);
+    let allkeys = [... new Set(akeys.concat(bkeys)) ];
+    let missinga = allkeys.filter(f => !akeys.includes(f)).map(m => current + m);
+    let missingb = allkeys.filter(f => !bkeys.includes(f)).map(m => current + m);
+    for (let k of allkeys) {
+        if (typeof a[k] !== 'string' && typeof b[k] !== 'string' && a[k] && b[k]) {
+            let deeper = comp(a[k], b[k], current + k);
+            missinga = missinga.concat(deeper.missinga);
+            missingb = missingb.concat(deeper.missingb);
+        }
+    }
+    return { missinga, missingb };
+}
+
+function main() {
+
+    const files = languages.map((lang) => `${STATIC_PATH}/${lang}/translation.json`);
+
+    const translations = {};
+    let x = 0;
+    for (let file of files) {
+        translations[languages[x++]] = JSON.parse(fs.readFileSync(file, 'utf-8'))
+    }
+
+    for (let l1 of languages) {
+        for (let l2 of languages) {
+            if (l1 === l2) continue;
+            console.log(`\n\n------------------------\nCompare ${l1} to ${l2}`);
+            if (!translations[l1]) {
+                console.log(`No translation for ${l1}`)
+                process.exit(-1);
+            }
+            if (!translations[l2]) {
+                console.log(`No translation for ${l2}`)
+                process.exit(-1);
+            }
+            const { missinga, missingb } = comp(translations[l1], translations[l2]);
+            if (missinga.length) {
+                console.log(`\nMissing from ${l1}\n`);
+                for (let m of missinga) {
+                    console.log(m);
+                }
+            }
+            if (missingb.length) {
+                console.log(`\nMissing from ${l2}\n`);
+                for (let m of missingb) {
+                    console.log(m);
+                }
+            }
+        }
+    }
+
+}
+
+main();

--- a/src/components/voyagecalculator/civas.tsx
+++ b/src/components/voyagecalculator/civas.tsx
@@ -64,7 +64,7 @@ export const CIVASMessage = (props: CIVASMessageProps) => {
 						})}
 					</p>
 					<Popup
-						content={exportState === ExportState.Done ? t('clipboard.copied_exclaim') : t('global.please_wait_ellipses')}
+						content={exportState === ExportState.Done ? t('clipboard.copied_exclaim') : t('spinners.calculating_voyage_estimate')}
 						on='click'
 						position='right center'
 						size='tiny'

--- a/static/structured/locales/de/translation.json
+++ b/static/structured/locales/de/translation.json
@@ -146,7 +146,7 @@
                 "antimatter": "Eigenschaften von Antimaterie",
                 "citeEffort": "Maximaler Aufwand",
                 "collections": "Sammlungen verbessern erhöhte Statistiken",
-                "equipment": "Rüstzeugspunktzahl",
+                "quipment": "Rüstzeugspunktzahl",
                 "groupSparsity": "Reisegruppenknappheit",
                 "improved": "Verbesserte Reise",
                 "magic": "Maßgrenze (Magische Zahl)",
@@ -1822,7 +1822,8 @@
         "battle_mode": "Kampfmodus",
         "battle_stations": "Kampfstationen",
         "bonus_ability": "Bonusfähigkeit",
-        "boosts": "Leistungssteigerung",
+        "boost": "Verstärkung",
+        "boosts": "Verstärkungen",
         "boosts_x_by_y": "Steigert {{x}} um {{y}}",
         "calc": {
             "advanced": {
@@ -2063,7 +2064,8 @@
             "name": "{{global.name}}",
             "owned": "{{crew_state.owned}}",
             "percentage": "Crew-Nachfragerate",
-            "popular_trait": "Häufigstes Merkmal"
+            "popular_trait": "Häufigstes Merkmal",
+            "quantity": "{{global.quantity}}"
         },
         "last_release": "Letzte Veröffentlichung",
         "new_high": "Neuer Highscore",
@@ -2279,7 +2281,7 @@
             "estimated_at": {
                 "estimated": "geschätzt um {{time}}",
                 "failed": "fehlgeschlagen um {{time}}",
-                "received": "zurückgerufen um {{time}}"
+                "recalled": "zurückgerufen um {{time}}"
             },
             "event_crew_bonus": "Ereignis-Crew-Bonus{{:}} {{n}}",
             "expected_range": "(erwarteter Bereich: {{a}} bis {{b}})",
@@ -2348,8 +2350,8 @@
         },
         "loading_voyage_tool_ellipses": "Reisetool wird geladen ...",
         "nonplayer": {
-            "Beschreibung": "Importieren Sie Ihre Spielerdaten, um dieses Tool an Ihre aktuelle Reise und Ihren aktuellen Kader anzupassen. Andernfalls können Sie manuell eine Reise erstellen und die beste Crew im Spiel für jede mögliche Konfiguration anzeigen.",
-            "Titel": "Keine Reisekonfiguration verfügbar"
+            "description": "Importieren Sie Ihre Spielerdaten, um dieses Tool an Ihre aktuelle Reise und Ihren aktuellen Kader anzupassen. Andernfalls können Sie manuell eine Reise erstellen und die beste Crew im Spiel für jede mögliche Konfiguration anzeigen.",
+            "title": "Keine Reisekonfiguration verfügbar"
         },
         "or_n_h_if_dupes_dismissed": "oder {{n}} {{h}}, wenn die gesamte doppelte Crew entlassen wird.",
         "overrun_problem_text": {
@@ -2489,7 +2491,7 @@
         "voyages": {
             "all": "Alle Reisen",
             "current": "Aktuelle Reisen",
-            "custom_voyages": "Individuelle Reisen",
+            "custom": "Individuelle Reisen",
             "upcoming": "Bevorstehende Reisen"
         }
     }

--- a/static/structured/locales/de/translation.json
+++ b/static/structured/locales/de/translation.json
@@ -1002,7 +1002,6 @@
         "or": "oder",
         "percentile": "Perzentil",
         "permalink": "Permalink",
-        "please_wait_ellipses": "Bitte warten...",
         "portal": "Zeitportal",
         "presets": "Presets",
         "quarter_short": "Q",
@@ -2031,6 +2030,7 @@
         "cite_opt": "Laden Ehrenvolle Erwähnung Optimierer...",
         "default": "Daten werden geladen…",
         "demands": "Crew fordert Berechnung...",
+        "please_wait": "Bitte warten...",
         "quipment": "Berechnungsausrüstung..."
     },
     "stat_trends": {

--- a/static/structured/locales/de/translation.json
+++ b/static/structured/locales/de/translation.json
@@ -1223,6 +1223,7 @@
                 },
                 "title": "Detaillierte Anleitung..."
             },
+            "paste_here_placeholder": "Fügen Sie hier Ihre {{data}} ein",
             "title": "Kopieren und Einfügen"
         },
         "or": "ODER",
@@ -1569,9 +1570,6 @@
     "retrieval": {
         "allow_unowned": "Unbesessene Crew zulassen",
         "assume_in_game_favorites": "Spielfavoriten dynamisch zur Wunschliste hinzufügen",
-        "calc_summary": "{{ship.calc.calc_summary}}",
-        "calculating_pct_ellipses": "{{ship.calc.calculating_pct_ellipses}}",
-        "calculating_pct_ellipses_verbose": "{{ship.calc.calculating_pct_ellipses_verbose}}",
         "combo": "Combo",
         "combo_length": "Combos Größe",
         "combo_needs": {
@@ -2149,6 +2147,34 @@
                 "initial_estimate": "Ihre anfängliche Schätzung war {{time}}."
             }
         },
+        "civas": {
+            "datatypes": {
+                "active": "hrer aktuellen Reise",
+                "recommended": "dieser Empfehlung"
+            },
+            "description": "Profi-Tipp: Verwenden Sie {{link}}, um den Überblick über Ihre Reisenden, Laufzeiten und Schätzungen zu behalten. Tippen Sie auf die Schaltfläche unten, um die Details {{datatype}} in die Zwischenablage zu kopieren, damit die relevanten Daten direkt in Ihr CIVAS Google Sheet (derzeit v{{version}}) eingefügt werden können.",
+            "title": "Captain Idol's Voyage Analysis Sheet"
+        },
+        "contests": {
+            "avg": "{{global.avg}}",
+            "contest_simulator": "Kampfsimulator",
+            "contestant": "Kämpfer",
+            "contestant_alt": "Kämpfer",
+            "crit_chance": "Kritische Trefferchance",
+            "max": "{{global.max}}",
+            "min": "{{global.min}}",
+            "n_viable_crew": "Ihre Reise verfügt über {{n}} geeignete Crewmitglieder für diesen Wettbewerb",
+            "no_skill": "Keine Fähigkeit",
+            "notes": {
+                "crit_icon": "represents a crew's number of potential crit traits.",
+                "scores": "Scores are the sum of a crew's average proficiency after 3 rolls per contest skill.",
+                "simulate_contestant": "Select a contestant to simulate in a {{skills}} contest."
+            },
+            "search_for_contestant": "Search for contestant",
+            "select_crit_chance": "Select crit chance",
+            "simulate_contest": "Simulate contest",
+            "wins": "Wins"
+        },
         "crew_finder_hints": {
             "best_rank": {
                 "optimal": "Wählen Sie das {{top}} für diesen Sitz aus",
@@ -2160,6 +2186,39 @@
             "on_voyage": "Auf Reise",
             "unfreeze_crew": "Crew freigeben"
         },
+        "crew_history": {
+            "fields": {
+                "average": "{{global.average}}",
+                "crew": "{{base.crew}}",
+                "last_used": "Zuletzt verwendet",
+                "rarity": "{{base.rarity}}",
+                "voyages": "{{base.voyages}}"
+            },
+            "notes": {
+                "skill_cells": "Die Fertigkeitstabellenzellen geben an, wie viel Prozent der Zeit die jeweilige Crew verwendet wird, wenn die Spalte die primäre oder sekundäre Reise ist.",
+                "skill_cells_primary": "Die Fertigkeitstabellenzellen geben an, wie viel Prozent der Zeit die jeweilige Crew verwendet wird, wenn die Spalte die primäre Reise ist."
+            },
+            "options": {
+                "report": "Reisen {{period}} anzeigen",
+                "report_period": {
+                    "half": "der letzten 180 Tage",
+                    "month": "des letzten Monats",
+                    "months": "der letzten 60 Tage",
+                    "quarter": "der letzten 90 Tage",
+                    "week": "der letzten Woche",
+                    "year": "des letzten Jahres"
+                }
+            },
+            "skill_modal": {
+                "header_detail": {
+                    "all": "{{voyage.voyages.all}}",
+                    "last_n_days": "Last {{n}} Days"
+                },
+                "notes": {
+                    "crew_skill": "Each cell indicates what percentage of time {{crew}} is used when the row is the voyage primary and the column is the voyage secondary."
+                }
+            }
+        },
         "current_voyage_x": "Aktuelle {{x}}",
         "custom": {
             "no_trait": "Kein Merkmal"
@@ -2170,6 +2229,40 @@
         "custom_voyage_editor": "Individueller Reiseeditor",
         "custom_voyage_x": "Individuelle {{x}}",
         "dilemma_chance_h_y": "Chance auf ein {{h}}-Stunden-Dilemma: {{y}} %",
+        "editor": {
+            "alternate_crew": "Alternative Reisecrew",
+            "alternate_crew_alt": "alternative Reisecrew",
+            "alternate_seats_for_crew": "Alternative Sitzplätze für {{crew}}",
+            "compared": "Im Vergleich zur bestehenden Empfehlung{{:}}",
+            "fields": {
+                "max_proficiency": "Maximale Kompetenz",
+                "voyage_score": "Reisepunktzahl",
+                "voyage_seat": "Reisesitz"
+            },
+            "missing_voyagers_message": "Bitte weisen Sie allen Reiseplätzen Crewmitglieder zu.",
+            "n_viable_crew": "Ihre voraussichtliche Reise verfügt über {{n}} Crewmitglieder mit dieser Fähigkeit",
+            "options": {
+                "show_prospective_voyagers": "Nur potenzielle Reisende anzeigen",
+                "skill_values": "Fähigkeitswerte in Tabelle anzeigen"
+            },
+            "prospective": {
+                "assigned_slot": "Voraussichtlicher Reisesitz",
+                "lineup": "Voraussichtliche Aufstellung",
+                "proficiency": "Voraussichtliche Kompetenz",
+                "skill_check": "Voraussichtliche Fähigkeitsüberprüfung",
+                "voyage": "Voraussichtliche Reise"
+            },
+            "reset_recommendation": "Auf vorhandene Empfehlung zurücksetzen",
+            "save_recommendation": "Als neue Empfehlung speichern",
+            "search_for_alternates": "Nach alternativer Crew suchen",
+            "select_slot": "Wählen Sie einen Reisesitz aus. Jede vorhandene Crew auf diesem Sitz wird durch {{crew}} ersetzt, was zu den aufgeführten Änderungen an der geplanten Reise führt.",
+            "slotted_message": "{{crew}} sitzt bereits als {{seat}} auf dieser geplanten Reise. Die folgenden Schätzungen berücksichtigen {{crew}} auf einem neuen Sitz, während der Sitz {{seat}} nicht zugewiesen wird.",
+            "target_seat": "Wählen Sie eine Crew für {{seat}} aus.",
+            "target_seat_replacement": "Wählen Sie eine Crew aus, die {{crew}} als {{seat}} ersetzen soll.",
+            "target_view_alternates": "oder tippen Sie unten auf eine beliebige Crew, um die alternative Crew für diesen Sitz anzuzeigen.",
+            "targeting_message": "Es werden nur mögliche {{seat}}-Alternativen angezeigt",
+            "view_voyage": "Voraussichtliche Reise anzeigen"
+        },
         "encounter_traits": "Kritische Begegnungsmerkmale",
         "estimate": {
             "1_refill": "1 Nachfüllung",
@@ -2237,6 +2330,7 @@
                 "manage": "Verlauf verwalten",
                 "voyages": "Reisen"
             },
+            "moved": "Das Reiseverlaufstool wurde in den {{link}} verschoben. Bitte aktualisieren Sie Ihre Lesezeichen nach Bedarf.",
             "not_yet": "Sie haben noch keinen Reiseverlauf. Beginnen Sie mit der Verfolgung von Reisen über den Crew-Rechner.",
             "title": "{{menu.tools.voyage_history}}"
         },
@@ -2253,6 +2347,10 @@
             "title": "Reiseaufstellung"
         },
         "loading_voyage_tool_ellipses": "Reisetool wird geladen ...",
+        "nonplayer": {
+            "Beschreibung": "Importieren Sie Ihre Spielerdaten, um dieses Tool an Ihre aktuelle Reise und Ihren aktuellen Kader anzupassen. Andernfalls können Sie manuell eine Reise erstellen und die beste Crew im Spiel für jede mögliche Konfiguration anzeigen.",
+            "Titel": "Keine Reisekonfiguration verfügbar"
+        },
         "or_n_h_if_dupes_dismissed": "oder {{n}} {{h}}, wenn die gesamte doppelte Crew entlassen wird.",
         "overrun_problem_text": {
             "line_1": "WARNUNG!!! Es wurde ein potenzielles Problem mit der gemeldeten Reisezeit erkannt.",
@@ -2286,6 +2384,22 @@
             "voyage_prefs": "Bevorzugte Fähigkeiten der Reise",
             "voyage_prefs_explain": "Wenn eine bevorzugte Reisefertigkeit ausgewählt wird, wird die Fertigkeitsreihenfolge der Crew so sortiert, dass passende Fertigkeiten zuerst angezeigt werden."
         },
+        "results": {
+            "actions": {
+                "abort": "Abbrechen",
+                "confident": "Erhalten Sie eine zuverlässigere Schätzung",
+                "dismiss": "Diese Empfehlung ablehnen",
+                "edit": "Aufstellung bearbeiten",
+                "track": "Diese Empfehlung verfolgen"
+            },
+            "messages": {
+                "calculating": "Berechnung läuft. Bitte warten...",
+                "completed_with_inputs": "Berechnet vom {{calculator}}-Rechner ({{inputs}}) in {{seconds}} Sekunden!",
+                "failed_with_inputs": "Der Reiserechner kann keine Aufstellungen für die angeforderten Optionen ({{inputs}}) empfehlen. Bitte versuchen Sie es erneut mit anderen Optionen.",
+                "generic_error": "Beim Reiserechner ist ein Fehler aufgetreten!"
+            }
+        },
+        "running_voyage": "Aktive Reise",
         "seats": {
             "captain_slot": "Erster Offizier",
             "chief_communications_officer": "Kommunikationsoffizier",
@@ -2300,6 +2414,18 @@
             "science_officer": "Stellvertretender Wissenschaftsoffizier",
             "security_officer": "Taktischer Offizier"
         },
+        "show_all_voyages": "Alle Reisen anzeigen",
+        "skill_check": {
+            "fields": {
+                "best_minimum": "Bestes Minimum",
+                "best_proficiency": "Beste Kompetenz",
+                "crew_with_skill": "Crew mit Fähigkeit",
+                "fail_point": "Fehlerpunkt bei Fähigkeitsprüfung",
+                "paired_skills": "Gepaarte Fähigkeiten",
+                "voyage_score": "Reisepunktzahl"
+            },
+            "title": "Fähigkeitstest"
+        },
         "skills": {
             "primary": {
                 "name": "Primäre Fähigkeit",
@@ -2309,6 +2435,13 @@
                 "name": "Sekundäre Fähigkeit",
                 "placeholder": "{{base.secondary}}"
             }
+        },
+        "telemetry": {
+            "description": "Wir verwenden aus Reiseroutenberechnungen aggregierte anonyme Statistiken, um DataCore zu verbessern und unsere {{link}} zu füllen.",
+            "options": {
+                "opt_in": "Erlauben Sie DataCore, anonyme Reisestatistiken zu sammeln"
+            },
+            "title": "Datenschutzhinweis"
         },
         "tracking": {
             "not_tracking": "Sie verfolgen diese Reise nicht.",
@@ -2321,8 +2454,37 @@
         "unable_to_track_revivals": "DataCore kann nicht automatisch verfolgen, wann eine Reise wiederbelebt wurde, aber Sie können die Wiederbelebung hier manuell vermerken.",
         "view": {
             "active_voyage": "Laufende Reise anzeigen",
+            "all_voyages": "Alle Reisen anzeigen",
             "crew_calculator": "Crew-Rechner anzeigen",
             "voyage_history": "Reiseverlauf anzeigen"
+        },
+        "voyage_history": {
+            "delete_from_history": "Reise aus Verlauf löschen",
+            "export_history": "Verlauf auf Gerät speichern",
+            "fields": {
+                "antimatter": "{{ship.antimatter}}",
+                "date": "{{base.date}}",
+                "initial_estimate": "Erste Schätzung",
+                "last_estimate": "Letzte Schätzung",
+                "primary": "{{base.primary}}",
+                "secondary": "{{base.secondary}}",
+                "ship_trait": "{{base.ship_trait}}"
+            },
+            "manage_placeholder": "Remote-Synchronisierung und andere Optionen zur Verlaufsverwaltung sind in der Entwicklung.",
+            "options": {
+                "revival": {
+                    "hide": "Wiederbelebte Reisen verbergen",
+                    "revived": "Nur wiederbelebte Reisen anzeigen"
+                },
+                "voyage_skill": "Nur Reisen mit {{skill}} anzeigen"
+            },
+            "revived": "Diese Reise wurde wiederbelebt.",
+            "tips": {
+                "tip1": "Sobald Sie mit der Verfolgung einer Reise beginnen, aktualisieren Sie Ihre Spielerdaten, während die Reise läuft, um Ihre aktuelle Laufzeit und Schätzung automatisch zu verfolgen.",
+                "tip2": "Sie sollten die Reise im Spiel überprüfen, kurz bevor Sie Ihre Spielerdaten in DataCore importieren. Ihre verbleibende Antimaterie wird in Ihren Spielerdaten nur aktualisiert, wenn die angezeigte Reiselaufzeit im Spiel aktualisiert wird, was zu veralteten Schätzungen in DataCore führen kann.",
+                "tip3": "Da Reisen jederzeit zurückgerufen werden können, verwenden wir letzte Schätzungen (anstelle der tatsächlichen Reiselaufzeiten) als konsistentere Metrik zum Vergleichen der Reiselängen. Wir empfehlen, Ihre Spielerdaten nach dem Zurückrufen einer Reise zu aktualisieren, um Ihre Rückrufzeit zu verfolgen und eine endgültige letzte Schätzung zu erhalten.",
+                "title": "Tipps"
+            }
         },
         "voyages": {
             "all": "Alle Reisen",

--- a/static/structured/locales/en/translation.json
+++ b/static/structured/locales/en/translation.json
@@ -2233,7 +2233,7 @@
             "alternate_crew": "Alternate Voyage Crew",
             "alternate_crew_alt": "alternate voyage crew",
             "alternate_seats_for_crew": "Alternate Seats for {{crew}}",
-            "compared": "Compared to the existing recommendation:",
+            "compared": "Compared to the existing recommendation{{:}}",
             "fields": {
                 "max_proficiency": "Max Proficiency",
                 "voyage_score": "Voyage Score",

--- a/static/structured/locales/en/translation.json
+++ b/static/structured/locales/en/translation.json
@@ -1822,6 +1822,7 @@
         "battle_mode": "Battle mode",
         "battle_stations": "Battle Stations",
         "bonus_ability": "Bonus Ability",
+        "boost": "Boost",
         "boosts": "Boosts",
         "boosts_x_by_y": "Boosts {{x}} by {{y}}",
         "calc": {
@@ -2061,6 +2062,7 @@
             "latest_crew": "{{stat_trends.trait_columns.latest_crew}}",
             "latest_usage": "Latest usage",
             "name": "{{global.name}}",
+            "owned": "{{crew_state.owned}}",
             "percentage": "Crew demand rate",
             "popular_trait": "Most frequent trait",
             "quantity": "{{global.quantity}}"

--- a/static/structured/locales/en/translation.json
+++ b/static/structured/locales/en/translation.json
@@ -1002,7 +1002,6 @@
         "or": "or",
         "percentile": "Percentile",
         "permalink": "permalink",
-        "please_wait_ellipses": "Please wait...",
         "portal": "Portal",
         "presets": "Presets",
         "quarter_short": "Q",
@@ -2029,6 +2028,7 @@
         "cite_opt": "Loading citation optimizer...",
         "default": "Loading data...",
         "demands": "Calculating crew demands...",
+        "please_wait": "Please wait...",
         "quipment": "Calculating quipment..."
     },
     "stat_trends": {

--- a/static/structured/locales/fr/translation.json
+++ b/static/structured/locales/fr/translation.json
@@ -1235,6 +1235,7 @@
                 },
                 "title": "Des instructions détaillées..."
             },
+            "paste_here_placeholder": "Collez vos {{data}} ici",
             "title": "Copier et Coller"
         },
         "or": "OU",
@@ -2162,6 +2163,34 @@
                 "initial_estimate": "Votre estimation initiale était de {{time}}."
             }
         },
+        "civas": {
+            "datatypes": {
+                "active": "votre parcours de voyage",
+                "recommended": "cette recommandation"
+            },
+            "description": "Conseil de pro : utilisez {{link}} pour vous aider à suivre vos déplacements, vos temps d'exécution et vos estimations. Appuyez sur le bouton ci-dessous pour copier les détails de {{datatype}} dans le presse-papiers afin que les données pertinentes puissent être collées directement dans votre feuille Google CIVAS (actuellement v{{version}}).",
+            "title": "Captain Idol's Voyage Analysis Sheet"
+        },
+        "contests": {
+            "avg": "{{global.avg}}",
+            "contest_simulator": "Simulateur de combat",
+            "contestant": "Combattant",
+            "contestant_alt": "combattant",
+            "crit_chance": "Chances de critique",
+            "max": "{{global.max}}",
+            "min": "{{global.min}}",
+            "n_viable_crew": "Votre voyage a {{n}} d'équipiers viables pour ce concours",
+            "no_skill": "Aucune compétence",
+            "notes": {
+                "crit_icon": "represents a crew's number of potential crit traits.",
+                "scores": "Scores are the sum of a crew's average proficiency after 3 rolls per contest skill.",
+                "simulate_contestant": "Select a contestant to simulate in a {{skills}} contest."
+            },
+            "search_for_contestant": "Search for contestant",
+            "select_crit_chance": "Select crit chance",
+            "simulate_contest": "Simulate contest",
+            "wins": "Wins"
+        },
         "crew_finder_hints": {
             "best_rank": {
                 "optimal": "Sélectionnez le {{top}} pour ce siège",
@@ -2173,6 +2202,39 @@
             "on_voyage": "En voyage",
             "unfreeze_crew": "Dégeler l'équipier"
         },
+        "crew_history": {
+            "fields": {
+                "average": "{{global.average}}",
+                "crew": "{{base.crew}}",
+                "last_used": "Dernière utilisation",
+                "rarity": "{{base.rarity}}",
+                "voyages": "{{base.voyages}}"
+            },
+            "notes": {
+                "skill_cells": "Les cellules de compétences indiquent le pourcentage de temps pendant lequel l'équipage respectif est utilisé lorsque la colonne est la colonne principale ou secondaire du voyage.",
+                "skill_cells_primary": "Les cellules du tableau des compétences indiquent le pourcentage de temps pendant lequel l'équipage respectif est utilisé lorsque la colonne est la colonne principale du voyage."
+            },
+            "options": {
+                "report": "Afficher les voyages {{period}}",
+                "report_period": {
+                    "half": "des 180 derniers jours",
+                    "month": "du mois dernier",
+                    "months": "des 60 derniers jours",
+                    "quarter": "des 90 derniers jours",
+                    "week": "de la semaine dernière",
+                    "year": "de l'année dernière"
+                }
+            },
+            "skill_modal": {
+                "header_detail": {
+                    "all": "{{voyage.voyages.all}}",
+                    "last_n_days": "Last {{n}} Days"
+                },
+                "notes": {
+                    "crew_skill": "Each cell indicates what percentage of time {{crew}} is used when the row is the voyage primary and the column is the voyage secondary."
+                }
+            }
+        },
         "current_voyage_x": "{{x}} actuel",
         "custom": {
             "no_trait": "Aucun trait"
@@ -2183,6 +2245,40 @@
         "custom_voyage_editor": "Éditeur de voyages personnalisés",
         "custom_voyage_x": "{{x}} personnalisé",
         "dilemma_chance_h_y": "Probabilité d'un dilemme de {{h]} heures : {{y}} %",
+        "editor": {
+            "alternate_crew": "Équipage de voyage alternatif",
+            "alternate_crew_alt": "équipage de voyage alternatif",
+            "alternate_seats_for_crew": "Sièges alternatifs pour {{crew}}",
+            "compared": "Par rapport à la recommandation existante{{:}}",
+            "fields": {
+                "max_proficiency": "Compétence maximale",
+                "voyage_score": "Score de voyage",
+                "voyage_seat": "Siège de voyage"
+            },
+            "missing_voyagers_message": "Veuillez affecter un équipier à tous les sièges du voyage.",
+            "n_viable_crew": "Votre futur voyage compte {{n}} équipiers possédant cette compétence",
+            "options": {
+                "show_prospective_voyagers": "Afficher uniquement les voyageurs potentiels",
+                "skill_values": "Afficher les valeurs de compétences dans le tableau"
+            },
+            "prospective": {
+                "assigned_slot": "Prospective Voyage Seat",
+                "lineup": "Proposition de composition",
+                "proficiency": "Compétence prospective",
+                "skill_check": "Vérification des compétences prospectives",
+                "voyage": "Voyage prospectif"
+            },
+            "reset_recommendation": "Réinitialiser la recommandation existante",
+            "save_recommendation": "Enregistrer comme nouvelle recommandation",
+            "search_for_alternates": "Rechercher un équipage alternatif",
+            "select_slot": "Sélectionnez un siège de voyage. Tout équipage existant sur ce siège sera remplacé par {{crew}}, ce qui entraînera les modifications répertoriées pour le voyage potentiel.",
+            "slotted_message": "{{crew}} est déjà assis en tant que {{seat}} sur ce voyage potentiel. Les estimations ci-dessous tiennent compte de {{crew}} dans un nouveau siège tout en laissant le siège {{seat}} non attribué.",
+            "target_seat": "Sélectionnez un équipage pour {{seat}}.",
+            "target_seat_replacement": "Sélectionnez un équipage pour remplacer {{crew}} en tant que {{seat}}.",
+            "target_view_alternates": "ou appuyez sur n'importe quel équipage ci-dessous pour afficher l'équipage alternatif pour ce siège.",
+            "targeting_message": "Afficher uniquement les alternatives viables pour {{seat}}",
+            "view_voyage": "Afficher le voyage potentiel"
+        },
         "encounter_traits": "Traits critiques de rencontre",
         "estimate": {
             "1_refill": "1 recharge",
@@ -2250,6 +2346,7 @@
                 "manage": "Gérer l'historique",
                 "voyages": "Voyages"
             },
+            "moved": "L'outil Historique des voyages a été déplacé vers le {{link}}. Veuillez mettre à jour vos favoris si nécessaire.",
             "not_yet": "Vous n'avez pas encore d'historique de voyage. Commencez à suivre les voyages à partir du calculateur d'équipage.",
             "title": "{{menu.tools.voyage_history}}"
         },
@@ -2266,6 +2363,10 @@
             "title": "Composition du voyage"
         },
         "loading_voyage_tool_ellipses": "Chargement de l'outil de voyage...",
+        "nonplayer": {
+            "description": "Importez vos données de joueur pour adapter cet outil à votre voyage et à votre liste actuels. Sinon, vous pouvez créer manuellement un voyage et afficher le meilleur équipage du jeu pour n'importe quelle configuration possible.",
+            "title": "Aucune configuration de voyage disponible"
+        },
         "or_n_h_if_dupes_dismissed": "ou {{n}} {{h}} si tous les équiipers en double sont renvoyés.",
         "overrun_problem_text": {
             "line_1": "ATTENTION !!! Un problème potentiel avec la durée de voyage signalée a été détecté.",
@@ -2299,6 +2400,22 @@
             "voyage_prefs": "Préférence de compétence de voyage",
             "voyage_prefs_explain": "Si une préférence de compétence de voyage est sélectionnée, l'ordre des compétences de l'équipage est trié de sorte que les compétences correspondantes viennent en premier."
         },
+        "results": {
+            "actions": {
+                "abort": "Abandonner",
+                "confident": "Obtenez une estimation plus fiable",
+                "dismiss": "Rejeter cette recommandation",
+                "edit": "Modifier la composition",
+                "track": "Suivre cette recommandation"
+            },
+            "messages": {
+                "calculating": "Calcul en cours. Veuillez patienter...",
+                "completed_with_inputs": "Calculé par la calculatrice {{calculator}} ({{inputs}}) en {{seconds}} secondes !",
+                "failed_with_inputs": "Le calculateur de voyage n'est pas en mesure de recommander des alignements pour les options demandées ({{inputs}}). Veuillez réessayer en utilisant des options différentes.",
+                "generic_error": "Le calculateur de voyage a rencontré une erreur !"
+            }
+        },
+        "running_voyage": "Voyage en cours d'exécution",
         "seats": {
             "captain_slot": "Premier officier",
             "chief_communications_officer": "Officier des communications",
@@ -2313,6 +2430,18 @@
             "science_officer": "Officier scientifique adjoint",
             "security_officer": "Officier tactique"
         },
+        "show_all_voyages": "Afficher tous les voyages",
+        "skill_check": {
+            "fields": {
+                "best_minimum": "Meilleur minimum",
+                "best_proficiency": "Meilleure compétence",
+                "crew_with_skill": "Équipage avec compétence",
+                "fail_point": "Point d'échec du contrôle de compétence",
+                "paired_skills": "Compétences jumelées",
+                "voyage_score": "Score de voyage"
+            },
+            "title": "Vérification des compétences"
+        },
         "skills": {
             "primary": {
                 "name": "Compétence principale",
@@ -2322,6 +2451,13 @@
                 "name": "Compétence secondaire",
                 "placeholder": "{{base.secondary}}"
             }
+        },
+        "telemetry": {
+            "description": "Nous utilisons des statistiques anonymes agrégées à partir de calculs de voyage pour améliorer DataCore et alimenter notre {{link}}.",
+            "options": {
+                "opt_in": "Autoriser DataCore à collecter des statistiques de voyage anonymes"
+            },
+            "title": "Avis de confidentialité"
         },
         "tracking": {
             "not_tracking": "Vous ne suivez pas ce voyage.",
@@ -2334,8 +2470,37 @@
         "unable_to_track_revivals": "DataCore ne peut pas suivre automatiquement le moment où un voyage a été relancé, mais vous pouvez noter manuellement la relance ici.",
         "view": {
             "active_voyage": "Afficher le voyage en cours",
+            "all_voyages": "Voir tous les voyages",
             "crew_calculator": "Afficher le calculateur d'équipage",
             "voyage_history": "Afficher l'historique des voyages"
+        },
+        "voyage_history": {
+            "delete_from_history": "Supprimer le voyage de l'historique",
+            "export_history": "Enregistrer l'historique sur l'appareil",
+            "fields": {
+                "antimatter": "{{ship.antimatter}}",
+                "date": "{{base.date}}",
+                "initial_estimate": "Estimation initiale",
+                "last_estimate": "Dernière estimation",
+                "primary": "{{base.primary}}",
+                "secondary": "{{base.secondary}}",
+                "ship_trait": "{{base.ship_trait}}"
+            },
+            "manage_placeholder": "La synchronisation à distance et d'autres options de gestion de l'historique sont en cours de développement.",
+            "options": {
+                "revival": {
+                    "hide": "Masquer les voyages réactivés",
+                    "revived": "Afficher uniquement les voyages réactivés"
+                },
+                "voyage_skill": "Afficher uniquement les voyages avec {{skill}}"
+            },
+            "revived": "Ce voyage a été relancé.",
+            "tips": {
+                "tip1": "Une fois que vous commencez à suivre un voyage, mettez à jour vos données de joueur pendant que votre voyage est en cours pour suivre automatiquement votre durée d'exécution actuelle et votre estimation.",
+                "tip2": "Vous souhaiterez peut-être vérifier le voyage dans le jeu peu de temps avant d'importer vos données de joueur dans DataCore. Votre antimatière restante n'est mise à jour dans vos données de joueur que lorsque la durée d'exécution du voyage affichée est mise à jour dans le jeu, ce qui peut conduire à des estimations obsolètes sur DataCore.",
+                "tip3": "Étant donné que les voyages peuvent être rappelés à tout moment, nous utilisons les dernières estimations (plutôt que les durées de voyage réelles) comme mesure plus cohérente pour comparer les durées de voyage. Nous vous recommandons de mettre à jour vos données de joueur après avoir rappelé un voyage pour garder une trace de votre temps de rappel et pour obtenir une dernière estimation finale.",
+                "title": "Conseils"
+            }
         },
         "voyages": {
             "all": "Tous les Voyages",

--- a/static/structured/locales/fr/translation.json
+++ b/static/structured/locales/fr/translation.json
@@ -1582,9 +1582,6 @@
     "retrieval": {
         "allow_unowned": "Autoriser l'équipage sans propriétaire",
         "assume_in_game_favorites": "Ajoutez dynamiquement les favoris du jeu à la liste de souhaits",
-        "calc_summary": "{{ship.calc.calc_summary}}",
-        "calculating_pct_ellipses": "{{ship.calc.calculating_pct_ellipses}}",
-        "calculating_pct_ellipses_verbose": "{{ship.calc.calculating_pct_ellipses_verbose}}",
         "combo": "Combo",
         "combo_length": "Taille des combos",
         "combo_needs": {
@@ -1641,7 +1638,7 @@
             "listed": "Répertorié",
             "min_polestars": "Min. allumettes d'étoile polaire",
             "modes": {
-                "list_price": "{{retrieval.market.columns.high}}",
+                "high": "{{retrieval.market.columns.high}}",
                 "orders": "Ordres non exécutées",
                 "sold_last_day": "Vente la plus rapide"
             },
@@ -2079,7 +2076,8 @@
             "name": "{{global.name}}",
             "owned": "{{crew_state.owned}}",
             "percentage": "Taux de demande de l'équipage",
-            "popular_trait": "Trait le plus fréquent"
+            "popular_trait": "Trait le plus fréquent",
+            "quantity": "{{global.quantity}}"
         },
         "last_release": "Dernière publication",
         "new_high": "Nouveau Élevé",
@@ -2375,7 +2373,7 @@
         },
         "picker_options": {
             "encounter_traits": "Équilibrez les compétences avec les bonus de traits critiques",
-            "freezen": "Considérez l'équipage gelé",
+            "frozen": "Considérez l'équipage gelé",
             "shuttle": "Considérez l'équipage sur les navettes actives",
             "sub_title": "Un total de {{n}} des équipiers seront pris en considération pour ce voyage.",
             "title": "Équipiers à prendre en considération",

--- a/static/structured/locales/fr/translation.json
+++ b/static/structured/locales/fr/translation.json
@@ -1012,7 +1012,6 @@
         "or": "ou",
         "percentile": "Centile",
         "permalink": "lien permanent",
-        "please_wait_ellipses": "S'il vous plaît, attendez...",
         "portal": "Portail",
         "presets": "Prédéfinies",
         "quarter_short": "T",
@@ -2044,6 +2043,7 @@
         "cite_opt": "Chargement l'Optimiseur des mentions honorable...",
         "default": "Chargement des données...",
         "demands": "Calcul des demandes de l'équipage...",
+        "please_wait": "S'il vous plaît, attendez...",
         "quipment": "Calcul de l'équipement..."
     },
     "stat_trends": {

--- a/static/structured/locales/sp/translation.json
+++ b/static/structured/locales/sp/translation.json
@@ -1012,7 +1012,6 @@
         "or": "o",
         "percentile": "Percentil",
         "permalink": "enlace permanente",
-        "please_wait_ellipses": "Espere por favor...",
         "portal": "Portal",
         "presets": "Preestablecidos",
         "quarter_short": "T",
@@ -2044,6 +2043,7 @@
         "cite_opt": "Cargando Distinción de Honor Optimizador...",
         "default": "Cargando datos...",
         "demands": "Cálculo de las demandas de la tripulante...",
+        "please_wait": "Espere por favor...",
         "quipment": "Quipo de cálculo..."
     },
     "stat_trends": {

--- a/static/structured/locales/sp/translation.json
+++ b/static/structured/locales/sp/translation.json
@@ -53,8 +53,6 @@
         "live_results": "Resultados en vivo (el cálculo será más lento)",
         "n_slots": "{{n}} espacios",
         "n_to_next": "{{n}} al próximo",
-        "n_total_x": "{{n}} {{x}} en total",
-        "n_x": "{{n}} {{x}}",
         "never_in_portal": "Nunca en el portal",
         "not_in_portal": "No en el portal",
         "not_uniquely_retrievable": "No se puede recuperar de forma única",
@@ -175,7 +173,7 @@
         "calc_specific_rarity": "Calcular rareza específica",
         "columns": {
             "antimatter_traits": "Rasgos\nde antimateria",
-            "comparar": "Comparar",
+            "compare": "Comparar",
             "crew": "{{base.crew}}",
             "ev_per_cite": "VE por\ncita",
             "final_ev": "VE final",
@@ -637,7 +635,7 @@
                     "solved_nodes": "Nodos resueltos",
                     "traits": "Rasgos",
                     "unique": "Único",
-                    "valores predeterminados": "valores predeterminados"
+                    "defaults": "valores predeterminados"
                 },
                 "title": "Personalizar exportación"
             },
@@ -698,7 +696,7 @@
             "user_prefs": {
                 "confirm_solves": "Confirmar rasgo resuelto",
                 "show_ship_ability": "Mostrar capacidad del buque",
-                "título": "Preferencias de usuario"
+                "title": "Preferencias de usuario"
             },
             "warn": "Es posible que las soluciones correctas no aparezcan en la lista con la configuración actual."
         },
@@ -806,7 +804,6 @@
         "note_owned_crew_power_calc_msg": "Nota: Si se detecta tripulación propia, entonces su nivel actual en su lista puede usarse para calcular su rango, dependiendo de la configuración del filtro.",
         "note_unleveled_crew_max_highlight_pair_msg": "Nota: Los equipos propios sin nivel que se muestran al máximo tienen competencias subrayadas y resaltadas en verde.",
         "note_unleveled_crew_max_highlight_table_msg": "Nota: Los equipos propios sin nivel que se muestran al máximo están resaltados en verde.",
-        "notes": {},
         "only_highlight_active_round": "Resaltar solo la ronda activa",
         "opponent_table": {
             "opponent": "Oponente",
@@ -993,6 +990,7 @@
         "n_%": "{{n}}%",
         "n_available": "{{n}} disponible",
         "n_results": "{{n}} resultados",
+        "n_total_x": "{{n}} {{x}} en total",
         "n_x": "{{n}} {{x}}",
         "na": "N/A",
         "name": "Nombre",
@@ -1521,6 +1519,13 @@
         "top_quipment": "Quipo de primera"
     },
     "rank_names": {
+        "advantage": {
+            "d": "D",
+            "defense": "Defensa (Reparación/Evasión)",
+            "o": "O",
+            "offense": "Ofensa (Precisión/Daño)",
+            "select": "Seleccione una ventaja"
+        },
         "arena_rank": "Arena",
         "bigbook_tier": "Piso de Big Book",
         "cab_grade": "Grado CAB",
@@ -1562,13 +1567,6 @@
         "voyage_rank": "Rango de Viaje"
     },
     "ranking_method": {
-        "advantage": {
-            "d": "D",
-            "defense": "Defensa (Reparación/Evasión)",
-            "o": "O",
-            "offense": "Ofensa (Precisión/Daño)",
-            "select": "Seleccione una ventaja"
-        },
         "delta_t": "Delta T",
         "early_boom": "Máximo Más Temprano",
         "guaranteed_minimum": "Mínimo garantizado",
@@ -1582,9 +1580,6 @@
     "retrieval": {
         "allow_unowned": "Permitir tripulación sin propietario",
         "assume_in_game_favorites": "Agregar dinámicamente los favoritos del juego a la lista de deseos",
-        "calc_summary": "{{ship.calc.calc_summary}}",
-        "calculating_pct_ellipses": "{{ship.calc.calculating_pct_ellipses}}",
-        "calculating_pct_ellipses_verbose": "{{ship.calc.calculating_pct_ellipses_verbose}}",
         "combo": "Combo",
         "combo_length": "Tamaño de los combos",
         "combo_needs": {
@@ -2079,7 +2074,8 @@
             "name": "{{global.name}}",
             "owned": "{{crew_state.owned}}",
             "percentage": "Tasa de demanda de la tripulación",
-            "popular_trait": "Rasgo más frecuente"
+            "popular_trait": "Rasgo más frecuente",
+            "quantity": "{{global.quantity}}"
         },
         "last_release": "Último lanzamiento",
         "new_high": "Nueva Máxima",
@@ -2374,7 +2370,7 @@
             "line_3": "Abra el juego y luego regrese a DataCore con una copia nueva de sus datos de jugador para garantizar una estimación más precisa."
         },
         "picker_options": {
-            "congelado": "Considere tripulación congelada",
+            "frozen": "Considere tripulación congelada",
             "encounter_traits": "Equilibra las competencias con las bonificaciones de rasgos críticos",
             "shuttle": "Considere tripulación en lanzaderas activas",
             "sub_title": "Se considerará un total de {{n}} tripulantes para este viaje.",

--- a/static/structured/locales/sp/translation.json
+++ b/static/structured/locales/sp/translation.json
@@ -1235,6 +1235,7 @@
                 },
                 "title": "Instrucciones detalladas..."
             },
+            "paste_here_placeholder": "Pegue sus {{data}} aquí",
             "title": "Copiar y Pegar"
         },
         "or": "O",
@@ -2162,6 +2163,34 @@
                 "initial_estimate": "Su estimación inicial fue {{time}}."
             }
         },
+        "civas": {
+            "datatypes": {
+                "active": "su viaje al portapapeles",
+                "recommended": "esta recomendación"
+            },
+            "description": "Consejo profesional: usa {{link}} para ayudarte a llevar un registro de tus viajeros, tiempos de ejecución y estimaciones. Pulsa el botón a continuación para copiar los detalles de {{datatype}} al portapapeles para que los datos relevantes se puedan pegar directamente en tu CIVAS Google Sheet (actualmente v{{version}}).",
+            "title": "Captain Idol's Voyage Analysis Sheet"
+        },
+        "contests": {
+            "avg": "{{global.avg}}",
+            "contest_simulator": "Simulador de combate",
+            "contestant": "Combatiente",
+            "contestant_alt": "combatiente",
+            "crit_chance": "Probabilidad crítica",
+            "max": "{{global.max}}",
+            "min": "{{global.min}}",
+            "n_viable_crew": "Su viaje tiene {{n}} tripulantes viables para este concurso",
+            "no_skill": "Sin habilidad",
+            "notes": {
+                "crit_icon": "represents a crew's number of potential crit traits.",
+                "scores": "Scores are the sum of a crew's average proficiency after 3 rolls per contest skill.",
+                "simulate_contestant": "Select a contestant to simulate in a {{skills}} contest."
+            },
+            "search_for_contestant": "Search for contestant",
+            "select_crit_chance": "Select crit chance",
+            "simulate_contest": "Simulate contest",
+            "wins": "Wins"
+        },
         "crew_finder_hints": {
             "best_rank": {
                 "optimal": "Selecciona el {{top}} para este puesto",
@@ -2173,6 +2202,39 @@
             "on_voyage": "En viaje",
             "unfreeze_crew": "Descongelar equipo"
         },
+        "crew_history": {
+            "fields": {
+                "average": "{{global.average}}",
+                "crew": "{{base.crew}}",
+                "last_used": "Último utilizado",
+                "rarity": "{{base.rarity}}",
+                "voyages": "{{base.voyages}}"
+            },
+            "notes": {
+                "skill_cells": "Las celdas de habilidad indican qué porcentaje de tiempo se utiliza la respectiva tripulación cuando la columna es la principal o secundaria del viaje.",
+                "skill_cells_primary": "Las celdas de habilidad indican qué porcentaje de tiempo se utiliza la respectiva tripulación cuando la columna es la principal del viaje."
+            },
+            "options": {
+                "report": "Mostrar viajes {{period}}",
+                "report_period": {
+                    "half": "de los últimos 180 días",
+                    "month": "del último mes",
+                    "months": "de los últimos 60 días",
+                    "quarter": "de los últimos 90 días",
+                    "week": "de la última semana",
+                    "year": "del último año"
+                }
+            },
+            "skill_modal": {
+                "header_detail": {
+                    "all": "{{voyage.voyages.all}}",
+                    "last_n_days": "Last {{n}} Days"
+                },
+                "notes": {
+                    "crew_skill": "Each cell indicates what percentage of time {{crew}} is used when the row is the voyage primary and the column is the voyage secondary."
+                }
+            }
+        },
         "current_voyage_x": "{{x}} actual",
         "custom": {
             "no_trait": "Sin rasgo"
@@ -2183,6 +2245,40 @@
         "custom_voyage_editor": "Editor de viajes personalizado",
         "custom_voyage_x": " {{x}} personalizado",
         "dilemma_chance_h_y": "Probabilidad de un dilema de {{h}} horas: {{y}}%",
+        "editor": {
+            "alternate_crew": "Tripulación de viaje alternativa",
+            "alternate_crew_alt": "Tripulación de viaje alternativa",
+            "alternate_seats_for_crew": "Asientos alternativos para {{crew}}",
+            "compared": "En comparación con la recomendación existente{{:}}",
+            "fields": {
+                "max_proficiency": "Máxima competencia",
+                "voyage_score": "untuación del viaje",
+                "voyage_seat": "Asiento del viaje"
+            },
+            "missing_voyagers_message": "Por favor, asigne uno tripulante a todos los asientos del viaje.",
+            "n_viable_crew": "Su posible viaje tiene {{n}} tripulantes con esta habilidad",
+            "options": {
+                "show_prospective_voyagers": "Mostrar solo posibles viajeros",
+                "skill_values": "Mostrar valores de habilidades en la tabla"
+            },
+            "prospective": {
+                "assigned_slot": "Asiento de viaje prospectivo",
+                "lineup": "Alineación prospectiva",
+                "proficiency": "Competencia prospectiva",
+                "skill_check": "Prueba de habilidad prospectiva",
+                "voyage": "Viaje prospectivo"
+            },
+            "reset_recommendation": "Restablecer recomendación existente",
+            "save_recommendation": "Guardar como nueva recomendación",
+            "search_for_alternates": "Buscar tripulación alternativa",
+            "select_slot": "Seleccione un asiento para el viaje. Cualquier miembro de la tripulación existente en ese asiento será reemplazado por {{crew}}, lo que dará como resultado los cambios enumerados en el posible viaje.",
+            "slotted_message": "{{crew}} ya está sentado como {{seat}} en este posible viaje. Las estimaciones a continuación tienen en cuenta a {{crew}} en un nuevo asiento mientras que el asiento {{seat}} queda sin asignar.",
+            "target_seat": "Seleccione una tripulación para {{seat}}.",
+            "target_seat_replacement": "Seleccione una tripulación para reemplazar a {{crew}} como {{seat}}.",
+            "target_view_alternates": "o toque cualquier tripulación a continuación para ver la tripulación alternativa para ese asiento.",
+            "targeting_message": "Solo se muestran alternativas viables de {{seat}}",
+            "view_voyage": "Ver posible viaje"
+        },
         "encounter_traits": "Rasgos críticos de encuentro",
         "estimate": {
             "1_refill": "1 recarga",
@@ -2250,6 +2346,7 @@
                 "manage": "Administrar historial",
                 "voyages": "Viajes"
             },
+            "moved": "La herramienta Historial de viajes se ha trasladado a la {{link}}. Actualice sus marcadores según sea necesario.",
             "not_yet": "Aún no tienes ningún historial de viajes. Comienza a hacer un seguimiento de los viajes desde la calculadora de tripulación.",
             "title": "{{menu.tools.voyage_history}}"
         },
@@ -2266,6 +2363,10 @@
             "title": "Alineación de viajes"
         },
         "loading_voyage_tool_ellipses": "Cargando herramienta de viaje...",
+        "nonplayer": {
+            "description": "Importa tus datos de jugador para ayudar a adaptar esta herramienta a tu viaje y a tu plantilla actual. De lo contrario, puedes crear un viaje manualmente y ver la mejor tripulación del juego para cualquier configuración posible.",
+            "title": "No hay ninguna configuración de viaje disponible"
+        },
         "or_n_h_if_dupes_dismissed": "o {{n}} {{h}} si se despide a toda los tripulantes duplicada.",
         "overrun_problem_text": {
             "line_1": "¡¡¡ADVERTENCIA!!! Se ha detectado un posible problema con la duración del viaje informada.",
@@ -2299,6 +2400,22 @@
             "voyage_prefs": "Preferencia de habilidad de viaje",
             "voyage_prefs_explain": "Si se selecciona una preferencia de habilidad de viaje, el orden de habilidades de la tripulación se ordena de modo que las habilidades coincidentes aparezcan primero."
         },
+        "results": {
+            "actions": {
+                "abort": "Abortar",
+                "confident": "Obtenga una estimación más confiable",
+                "dismiss": "Descartar esta recomendación",
+                "edit": "Editar la lista de candidatos",
+                "track": "Seguir esta recomendación"
+            },
+            "messages": {
+                "calculating": "Cálculo en proceso. Espere...",
+                "completed_with_inputs": "Calculado por la calculadora {{calculator}} ({{inputs}}) en {{seconds}} segundos!",
+                "failed_with_inputs": "La calculadora de viajes no puede recomendar alineaciones para las opciones solicitadas ({{inputs}}). Inténtelo nuevamente con otras opciones.",
+                "generic_error": "¡La calculadora de viajes encontró un error!"
+            }
+        },
+        "running_voyage": "Viaje activo",
         "seats": {
             "captain_slot": "Primer oficial",
             "chief_communications_officer": "Oficial de comunicaciones",
@@ -2313,6 +2430,18 @@
             "science_officer": "Oficial científico adjunto",
             "security_officer": "Oficial táctico"
         },
+        "show_all_voyages": "Mostrar todos los viajes",
+        "skill_check": {
+            "fields": {
+                "best_minimum": "Mejor mínimo",
+                "best_proficiency": "Mejor competencia",
+                "crew_with_skill": "Tripulación con habilidad",
+                "fail_point": "Punto de falla en la prueba de habilidad",
+                "paired_skills": "Habilidades emparejadas",
+                "voyage_score": "Puntaje de travesía"
+            },
+            "title": "Comprobación de habilidades"
+        },
         "skills": {
             "primary": {
                 "name": "Habilidad primaria",
@@ -2322,6 +2451,13 @@
                 "name": "Habilidad secundaria",
                 "placeholder": "{{base.secondary}}"
             }
+        },
+        "telemetry": {
+            "description": "Utilizamos estadísticas anónimas agregadas a partir de cálculos de viaje para mejorar DataCore y potenciar nuestro {{link}}.",
+            "options": {
+                "opt_in": "Permitir que DataCore recopile estadísticas de viajes anónimas"
+            },
+            "title": "Aviso de privacidad"
         },
         "tracking": {
             "not_tracking": "No estás rastreando este viaje.",
@@ -2334,8 +2470,37 @@
         "unable_to_track_revivals": "DataCore no puede rastrear automáticamente cuándo se ha reanudado un viaje, pero puedes anotar manualmente la reanudación aquí.",
         "view": {
             "active_voyage": "Ver viaje en curso",
+            "all_voyages": "Ver todos los viajes",
             "crew_calculator": "Ver calculadora de tripulación",
             "voyage_history": "Ver historial de viaje"
+        },
+        "voyage_history": {
+            "delete_from_history": "Eliminar viaje del historial",
+            "export_history": "Guardar historial en el dispositivo",
+            "fields": {
+                "antimatter": "{{ship.antimatter}}",
+                "date": "{{base.date}}",
+                "initial_estimate": "Estimación inicial",
+                "last_estimate": "Última estimación",
+                "primary": "{{base.primary}}",
+                "secondary": "{{base.secondary}}",
+                "ship_trait": "{{base.ship_trait}}"
+            },
+            "manage_placeholder": "La sincronización remota y otras opciones de gestión del historial están en desarrollo.",
+            "options": {
+                "revival": {
+                    "hide": "Ocultar viajes revividos",
+                    "revived": "Mostrar solo viajes revividos"
+                },
+                "voyage_skill": "Mostrar solo viajes con {{skill}}"
+            },
+            "revived": "Este viaje fue reanudado.",
+            "tips": {
+                "tip1": "Una vez que comiences a rastrear un viaje, actualiza tus datos de jugador mientras tu viaje está en curso para rastrear automáticamente tu tiempo de ejecución actual y tu estimación.",
+                "tip2": "Quizás quieras verificar el viaje en el juego poco antes de importar tus datos de jugador a DataCore. Tu antimateria restante solo se actualiza en tus datos de jugador cuando el tiempo de ejecución del viaje que se muestra se actualiza en el juego, lo que puede generar estimaciones obsoletas en DataCore.",
+                "tip3": "Debido a que los viajes se pueden recuperar en cualquier momento, usamos las últimas estimaciones (en lugar de los tiempos de ejecución reales del viaje) como una métrica más consistente para comparar las duraciones de los viajes. Recomendamos actualizar tus datos de jugador después de recuperar un viaje para realizar un seguimiento de tu tiempo de recuperación y obtener una última estimación final.",
+                "title": "Consejos"
+            }
         },
         "voyages": {
             "all": "Todos los Viajes",


### PR DESCRIPTION
Moves `global.please_wait_ellipses` to `spinners.please_wait` (all locales). CIVAS now uses existing `spinners.calculating_voyage_estimate` instead of `please_wait`.

The following strings are still needed:

json.paste_here_placeholder
voyage.civas
voyage.contests
voyage.crew_history
voyage.editor
voyage.history.moved
voyage.nonplayer
voyage.results
voyage.running_voyage
voyage.show_all_voyages
voyage.skill_check
voyage.telemetry
voyage.view.all_voyages
voyage.voyage_history