### PR TITLE
Refactor Ship Table

### DIFF
--- a/src/components/event_info_tabs/event_information.tsx
+++ b/src/components/event_info_tabs/event_information.tsx
@@ -7,6 +7,7 @@ import CrewCard, { CrewCardBrief } from './crew_card';
 import { PlayerCrew } from '../../model/player';
 import { GlobalContext } from '../../context/globalcontext';
 import { CrewTarget } from '../hovering/crewhoverstat';
+import { Ship } from '../../model/ship';
 
 const contentTypeMap = {
 	gather: 'Galaxy',
@@ -48,9 +49,9 @@ function EventInformationTab(props: { eventData: GameEvent, lastEvent?: GameEven
 	const context = React.useContext(GlobalContext);
 	const { t, TRAIT_NAMES } = context.localized;
 
-	const { crew: allCrew } = context.core;
+	const { crew: allCrew, all_ships } = context.core;
 
-	const allShips = context.core.ship_schematics.map(m => m.ship);
+	const allShips = all_ships.map(ship => ({ ...ship, id: ship.archetype_id, levels: undefined }) as Ship);
 
 	const crewData = allCrew; // crewJson.edges.map(edge => edge.node) as PlayerCrew[];
 	const crewMap: { [key: string]: PlayerCrew } = {};

--- a/src/components/eventplanner/eventpicker.tsx
+++ b/src/components/eventplanner/eventpicker.tsx
@@ -17,7 +17,7 @@ import { applySkillBuff } from '../../utils/crewutils';
 
 import { IEventData, IRosterCrew } from './model';
 import { GatherPlanner } from '../gather/gather_planner';
-import ShipTable from '../ship/shiptable';
+import { ShipTable } from '../ship/shiptable';
 import { AvatarView } from '../item_presenters/avatarview';
 import { ShipHoverStat } from '../hovering/shiphoverstat';
 import { QuipmentProspectsOptions } from '../qpconfig/options';
@@ -174,12 +174,14 @@ export const EventPicker = (props: EventPickerProps) => {
 				</React.Fragment>
 			)}
 
-			{playerData && eventData.content_types[phaseIndex] === 'voyage' && eventData.activeContent?.content_type === 'voyage' &&
+			{eventData.content_types[phaseIndex] === 'voyage' && eventData.activeContent?.content_type === 'voyage' &&
 				<div style={{ marginTop: "0.5em" }}>
 					<div style={{ margin: "0.5em 0" }}>
 						<h4>{t('base.event_ships')}</h4>
 					</div>
-					<ShipTable event_ships={eventData.bonus_ships}
+					<ShipTable
+						pageId='event_picker'
+						event_ships={eventData.bonus_ships}
 						high_bonus={eventData.featured_ships}
 						event_ship_traits={eventData.activeContent?.antimatter_bonus_ship_traits}
 					/>

--- a/src/components/item_presenters/avatarview.tsx
+++ b/src/components/item_presenters/avatarview.tsx
@@ -6,8 +6,8 @@ import { EquipmentCommon, EquipmentItem } from "../../model/equipment";
 import { mergeItems } from "../../utils/itemutils";
 import { ItemTarget } from "../hovering/itemhoverstat";
 import { CrewTarget } from "../hovering/crewhoverstat";
-import { Schematics, Ship } from "../../model/ship";
-import { mergeShips } from "../../utils/shiputils";
+import { Ship } from "../../model/ship";
+import { mergeRefShips } from "../../utils/shiputils";
 import { ShipTarget } from "../hovering/shiphoverstat";
 import { navigate } from "gatsby";
 import { CrewMember } from "../../model/crew";
@@ -18,7 +18,7 @@ export type AvatarCrewBackground = 'normal' | 'rich';
 export interface AvatarViewProps {
     altItems?: (EquipmentItem | EquipmentCommon)[];
     altCrew?: (CrewMember | PlayerCrew)[];
-    altShips?: Schematics[];
+    altShips?: Ship[];
     /** Item type number or 'crew', 'item', or 'ship' */
     mode: AvatarViewMode | number;
     /** The symbol of the item to display */
@@ -93,7 +93,7 @@ export const AvatarView = (props: AvatarViewProps) => {
     const { playerData } = globalContext.player;
     const items = props.altItems ?? globalContext.core.items;
     const crew = props.altCrew ?? globalContext.core.crew;
-    const ship_schematics = props.altShips ?? globalContext.core.ship_schematics;
+    const all_ships = globalContext.core.all_ships;
     const { passDirect, substitute_kwipment, partialItem, style, quantity, showMaxRarity, id, size, ignorePlayer, hideRarity, targetGroup } = props;
     const symbol = props.symbol || props.item?.symbol;
     const crewBackground = props.crewBackground ?? 'normal';
@@ -329,7 +329,7 @@ export const AvatarView = (props: AvatarViewProps) => {
                 gen_item = playerData.player.character.ships.find(f => f.symbol === symbol?.replace("_schematic", "") || (id !== undefined && f.archetype_id?.toString() === id?.toString())) as BasicItem | undefined;
             }
             if (!gen_item) {
-                gen_item = ship_schematics.find(f => f.ship.symbol === symbol?.replace("_schematic", "") || (id !== undefined && f.ship.archetype_id?.toString() === id?.toString()))?.ship as BasicItem | undefined;
+                gen_item = all_ships.find(f => f.symbol === symbol?.replace("_schematic", "") || (id !== undefined && f.archetype_id?.toString() === id?.toString())) as BasicItem | undefined;
                 if (gen_item) {
                     gen_item = { ...gen_item };
                     gen_item.max_rarity = gen_item.rarity;
@@ -343,13 +343,13 @@ export const AvatarView = (props: AvatarViewProps) => {
         if (gen_item) {
             HoverTarget = ShipTarget;
             let pship = playerData ? gen_item as any as Ship : undefined;
-            let cship = ship_schematics.find(f => f.ship.symbol === symbol?.replace("_schematic", ""));
+            let cship = all_ships.find(f => f.symbol === symbol?.replace("_schematic", ""));
 
             if (pship && cship) {
-                ship = mergeShips([cship], [pship])[0];
+                ship = mergeRefShips([cship], [pship], globalContext.localized.SHIP_TRAIT_NAMES)[0];
             }
             else if (cship) {
-                ship = cship.ship;
+                ship = { ...cship, levels: undefined, id: cship.archetype_id  } as Ship;
             }
             else if (pship) {
                 ship = pship;

--- a/src/components/items/equipment_table.tsx
+++ b/src/components/items/equipment_table.tsx
@@ -146,7 +146,8 @@ export const EquipmentTable = (props: EquipmentTableProps) => {
     else return <React.Fragment>
         {!props.itemTargetGroup && <ItemHoverStat targetGroup={itemTargetGroup} />}
         <SearchableTable
-            hideExplanation
+            id={`${pageId}/items_table`}
+            hideExplanation={true}
             config={tableConfig}
             data={items}
             renderTableRow={renderTableRow}

--- a/src/components/page/datapagelayout.tsx
+++ b/src/components/page/datapagelayout.tsx
@@ -31,7 +31,7 @@ export interface DataPageLayoutProps {
 	pageDescriptionJSX?: JSX.Element;
 
 	/**
-	 * Default demands are crew, items, ship_schematics, all_buffs, and cadet
+	 * Default demands are crew, items, all_ships, all_buffs, and cadet
 	 */
 	demands?: ValidDemands[]
 
@@ -80,7 +80,7 @@ const DataPageLayout = <T extends DataPageLayoutProps>(props: T) => {
 
 	React.useEffect(() => {
 		const demands: ValidDemands[] = props.demands ?? [];
-		(['crew', 'collections', 'items', 'ship_schematics', 'all_buffs', 'cadet'] as ValidDemands[]).forEach(required => {
+		(['crew', 'collections', 'items', 'all_ships', 'all_buffs', 'cadet'] as ValidDemands[]).forEach(required => {
 			if (!demands.includes(required))
 				demands.push(required);
 		});

--- a/src/components/ship/staffingview.tsx
+++ b/src/components/ship/staffingview.tsx
@@ -7,7 +7,7 @@ import { GlobalContext } from "../../context/globalcontext"
 import { CrewMember } from "../../model/crew"
 import { PlayerCrew } from "../../model/player"
 import { BattleStation, Ship } from "../../model/ship"
-import { findPotentialCrew, mergeShips } from "../../utils/shiputils"
+import { findPotentialCrew, mergeRefShips } from "../../utils/shiputils"
 import { useStateWithStorage } from "../../utils/storage"
 import { OptionsPanelFlexColumn } from "../stats/utils"
 import { getShipBonus, getSkills } from "../../utils/crewutils"
@@ -49,7 +49,7 @@ export const ShipStaffingView = (props: ShipStaffingProps) => {
         setCrewStations
     } = props;
 	const { playerShips, playerData } = context.player;
-	const { crew: coreCrew, ship_schematics: coreShips } = context.core;
+	const { crew: coreCrew, all_ships: coreShips } = context.core;
 
     const [ships, setShips] = React.useState<Ship[]>(loadShips());
 	const [crew, setCrew] = React.useState<(PlayerCrew | CrewMember)[] | undefined>(undefined);
@@ -285,36 +285,8 @@ export const ShipStaffingView = (props: ShipStaffingProps) => {
 
 	function loadShips() {
 		if (!context) return [];
-		const schematics = [...context.core.ship_schematics];
-
-		const constellation = {
-			symbol: 'constellation_ship',
-			rarity: 1,
-			max_level: 5,
-			antimatter: 1250,
-			name: 'Constellation Class',
-			icon: { file: '/ship_previews_fed_constellationclass' },
-			traits: ['federation','explorer'],
-			battle_stations: [
-				{
-					skill: 'command_skill'
-				},
-				{
-					skill: 'diplomacy_skill'
-				}
-			],
-			owned: true
-		} as Ship;
-
-		schematics.push({
-			ship: constellation,
-			rarity: constellation.rarity,
-			cost: 0,
-			id: 1,
-			icon: constellation.icon!
-		});
-
-		let ships = mergeShips(schematics, context.player.playerData?.player.character.ships ?? []) ?? [];
+		const all_ships = [...context.core.all_ships];
+		let ships = mergeRefShips(all_ships, context.player.playerData?.player.character.ships ?? [], context.localized.SHIP_TRAIT_NAMES) ?? [];
 		return [...ships];
 	}
 
@@ -326,7 +298,6 @@ export const ShipStaffingView = (props: ShipStaffingProps) => {
 
 		setCurrentStation(index);
 		setCurrentStationCrew(newCrew);
-		//setModalOpen(true);
 	}
 
 	function clearStation(index?: number) {
@@ -338,7 +309,6 @@ export const ShipStaffingView = (props: ShipStaffingProps) => {
 			stations = stations.map(sta => undefined);
 		}
 		setCrewStations(stations);
-		//setModalOpen(false);
 		setCurrentStationCrew([]);
 		setCurrentStation(undefined);
 	}

--- a/src/components/voyagecalculator/home.tsx
+++ b/src/components/voyagecalculator/home.tsx
@@ -101,7 +101,7 @@ const NonPlayerHome = () => {
 
 	function getEvents(): void {
 		// Guess event from autosynced events
-		getRecentEvents(globalContext.core.crew, globalContext.core.event_instances, globalContext.core.ship_schematics.map(m => m.ship)).then(recentEvents => {
+		getRecentEvents(globalContext.core.crew, globalContext.core.event_instances, globalContext.core.all_ships.map(m => ({...m, id: m.archetype_id, levels: undefined }))).then(recentEvents => {
 			setEventData([...recentEvents]);
 		});
 	}
@@ -238,7 +238,7 @@ const PlayerHome = (props: PlayerHomeProps) => {
 		}
 		// Otherwise guess event from autosynced events
 		else {
-			getRecentEvents(globalContext.core.crew, globalContext.core.event_instances, globalContext.core.ship_schematics.map(m => m.ship)).then(recentEvents => {
+			getRecentEvents(globalContext.core.crew, globalContext.core.event_instances, globalContext.core.all_ships.map(m => ({...m, id: m.archetype_id, levels: undefined }))).then(recentEvents => {
 				setEventData([...recentEvents]);
 			});
 		}

--- a/src/context/datacontext.tsx
+++ b/src/context/datacontext.tsx
@@ -13,7 +13,7 @@ import { calcQuipmentScore } from '../utils/equipment';
 import { getItemWithBonus } from '../utils/itemutils';
 import { EventInstance, EventLeaderboard } from '../model/events';
 import { StaticFaction } from '../model/shuttle';
-import { highestLevel } from '../utils/shiputils';
+import { allLevelsToLevelStats, highestLevel, levelToLevelStats } from '../utils/shiputils';
 import { ObjectiveEvent } from '../model/player';
 import { ICoreData } from './coremodel';
 import { EventStats } from '../utils/event_stats';
@@ -206,6 +206,9 @@ export const DataProvider = (props: DataProviderProperties) => {
 					case 'items':
 						newData.items = processItems(result.json);
 						break;
+					case 'all_ships':
+						newData.all_ships = processAllShips(result.json);
+						break;
 					default:
 						newData[result.demand] = result.json;
 						break;
@@ -325,6 +328,15 @@ export const DataProvider = (props: DataProviderProperties) => {
 		return true;
 	}
 
+	function processAllShips(all_ships: ReferenceShip[]) {
+		for (let ship of all_ships) {
+			ship.id = ship.archetype_id;
+			ship.ranks ??= { overall: 0, arena: 0, fbb: 0, kind: 'ship', overall_rank: all_ships.length + 1, fbb_rank: all_ships.length + 1, arena_rank: all_ships.length + 1, divisions: { fbb: {}, arena: {} } }
+		}
+		data.ships = all_ships.map(ship => ({...ship, levels: allLevelsToLevelStats(ship.levels) }));
+		return all_ships;
+	}
+
 	function processCrew(result: CrewMember[]): CrewMember[] {
 		result.forEach((item) => {
 			if (typeof item.date_added === 'string') {
@@ -380,7 +392,7 @@ export const DataProvider = (props: DataProviderProperties) => {
 					}
 				}
 			}
-			data.ships = scsave;
+			//data.ships = scsave;
 		}
 	}
 

--- a/src/context/playercontext.tsx
+++ b/src/context/playercontext.tsx
@@ -5,7 +5,7 @@ import { DataContext, DataProviderProperties } from './datacontext';
 import { BuffStatTable, calculateBuffConfig, calculateMaxBuffs } from '../utils/voyageutils';
 import { prepareProfileData } from '../utils/crewutils';
 import { Ship } from '../model/ship';
-import { mergeShips } from '../utils/shiputils';
+import { mergeRefShips, mergeShips } from '../utils/shiputils';
 import { stripPlayerData } from '../utils/playerutils';
 import { BossBattlesRoot } from '../model/boss';
 import { ShuttleAdventure } from '../model/shuttle';
@@ -13,6 +13,7 @@ import { ArchetypeRoot20 } from '../model/archetype';
 import { getItemWithBonus } from '../utils/itemutils';
 import { TinyStore } from '../utils/tiny';
 import { EquipmentCommon, EquipmentItem } from '../model/equipment';
+import { ShipTraitNames } from '../model/traits';
 
 export interface PlayerContextData {
 	loaded: boolean;
@@ -82,7 +83,7 @@ const tiny = TinyStore.getStore(`global_playerSettings`);
 export const PlayerProvider = (props: DataProviderProperties) => {
 
 	const coreData = React.useContext(DataContext);
-	const { crew, ship_schematics } = coreData;
+	const { crew, ship_schematics, all_ships } = coreData;
 
 	const { children } = props;
 
@@ -114,7 +115,7 @@ export const PlayerProvider = (props: DataProviderProperties) => {
 	const [loaded, setLoaded] = React.useState(false);
 
 	React.useEffect(() => {
-		if (!input || !ship_schematics.length || !crew.length) return;
+		if (!input || (!all_ships.length) || !crew.length) return;
 		// ephemeral data (e.g. active crew, active shuttles, voyage data, and event data)
 		//	can be misleading when outdated, so keep a copy for the current session only
 		const activeCrew = [] as CompactCrew[];
@@ -173,8 +174,8 @@ export const PlayerProvider = (props: DataProviderProperties) => {
 		setProfile(preparedProfileData);
 
 		if (preparedProfileData) {
-			const schematics = JSON.parse(JSON.stringify(coreData.ship_schematics));
-			const mergedShips = mergeShips(schematics, preparedProfileData.player.character.ships);
+			const all_ships = JSON.parse(JSON.stringify(coreData.all_ships));
+			const mergedShips = mergeRefShips(all_ships, preparedProfileData.player.character.ships, {} as ShipTraitNames, false, true);
 			setPlayerShips(mergedShips);
 		}
 

--- a/src/model/ship.ts
+++ b/src/model/ship.ts
@@ -68,12 +68,14 @@ export interface ShipLevelStats {
 }
 
 export interface ReferenceShip extends ShipBonus {
+  id: number;
   archetype_id: number
   symbol: string
   name: string
   rarity: number
   icon: Icon
   flavor: string
+  traits_named?: string[];
   model: string
   max_level: number
   actions: ShipAction[]

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -56,6 +56,7 @@ const EventsPage = () => {
 				"cadet",
 				"all_buffs",
 				"items",
+				"all_ships",
 				"ship_schematics",
 				"event_instances",
 				"event_stats",

--- a/src/pages/items.tsx
+++ b/src/pages/items.tsx
@@ -170,12 +170,6 @@ const ItemsPage = (props: ItemsPageProps) => {
 					</ItemsFilterProvider>
 				</WorkerProvider>}
 
-				{/* {hasPlayer &&
-					<ItemsTable
-					pageName={"roster"}
-					noRender={activeTabIndex !== 1 || !hasPlayer} />
-				} */}
-
 				<QuipmentFilterProvider
 					noRender={activeTabIndex !== 2}
 					ownedItems={false}
@@ -190,19 +184,6 @@ const ItemsPage = (props: ItemsPageProps) => {
 						customFields={quipCust}
 						/>
 				</QuipmentFilterProvider>
-
-				{/* <ItemsTable
-					pageName={"quipment"}
-					types={[14]}
-					buffs={true}
-					crewMode={true}
-					noWorker={true}
-					noRender={activeTabIndex !== 2}
-					data={coreItems}
-					hideOwnedInfo={true}
-					flavor={false}
-					customFields={quipCust}
-				/> */}
 
 				<br />
 				<br />

--- a/src/pages/ship_info.tsx
+++ b/src/pages/ship_info.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { mergeShips, setupShip } from '../utils/shiputils';
+import { mergeRefShips, setupShip } from '../utils/shiputils';
 import { BattleMode, Ship } from '../model/ship';
 import { PlayerCrew } from '../model/player';
 import { CrewMember } from '../model/crew';
@@ -33,7 +33,7 @@ const ShipInfoPage = () => {
 		setShipKey(ship_key);
 	}, []);
 
-	return <DataPageLayout pageTitle={t('pages.ship_info')} demands={['ship_schematics', 'battle_stations']}>
+	return <DataPageLayout pageTitle={t('pages.ship_info')}>
 		<div>
 			{!!shipKey && <ShipViewer ship={shipKey} setShip={setShipKey} />}
 			{!shipKey && globalContext.core.spin(t('spinners.default'))}
@@ -220,40 +220,12 @@ const ShipViewer = (props: ShipViewerProps) => {
 
 	function loadShips() {
 		if (!context) return [];
-		const schematics = [...context.core.ship_schematics];
-
-		const constellation = {
-			symbol: 'constellation_ship',
-			rarity: 1,
-			max_level: 5,
-			antimatter: 1250,
-			name: 'Constellation Class',
-			icon: { file: '/ship_previews_fed_constellationclass' },
-			traits: ['federation','explorer'],
-			battle_stations: [
-				{
-					skill: 'command_skill'
-				},
-				{
-					skill: 'diplomacy_skill'
-				}
-			],
-			owned: true
-		} as Ship;
-
-		schematics.push({
-			ship: constellation,
-			rarity: constellation.rarity,
-			cost: 0,
-			id: 1,
-			icon: constellation.icon!
-		});
-
-		let ships = mergeShips(schematics, context.player.playerData?.player.character.ships ?? []) ?? [];
+		const { SHIP_TRAIT_NAMES } = context.localized;
+		const all_ships = [...context.core.all_ships];
+		let ships = mergeRefShips(all_ships, context.player.playerData?.player.character.ships ?? [], SHIP_TRAIT_NAMES) ?? [];
 		return [...ships];
 	}
 
 }
-
 
 export default ShipInfoPage;

--- a/src/pages/ships.tsx
+++ b/src/pages/ships.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import DataPageLayout from '../components/page/datapagelayout';
-import ShipTable from '../components/ship/shiptable';
+import { ShipTable } from '../components/ship/shiptable';
 import { GlobalContext } from '../context/globalcontext';
 import { WorkerProvider } from '../context/workercontext';
 
 const ShipsPage = () => {
     const { t } = React.useContext(GlobalContext).localized;
     return <DataPageLayout demands={['all_ships']} playerPromptType='recommend' pageTitle={t('pages.ships')}>
-        <ShipTable />
+        <ShipTable pageId='main_ship_table' />
     </DataPageLayout>
 }
 

--- a/src/pages/testpage.tsx
+++ b/src/pages/testpage.tsx
@@ -12,7 +12,7 @@ const TestPage = () => {
     return <>
         <DataPageLayout
             pageTitle='test'
-            demands={['items', 'crew', 'ship_schematics']}>
+            demands={['items', 'crew', 'all_ships', 'ship_schematics']}>
             <TestComponent />
         </DataPageLayout>
     </>

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -243,9 +243,9 @@ export async function getRecentEvents(allCrew: CrewMember[], allEvents: EventIns
 			eventData.seconds_to_start = start;
 			eventData.seconds_to_end = end;
 			// Assume in phase 2 of ongoing event
-			if (eventData.content_types.length === 2 && end < 2*24*60*60) {
-				eventData.content_types = [eventData.content_types[1]];
-			}
+			// if (eventData.content_types.length === 2 && end < 2*24*60*60) {
+			// 	eventData.content_types = [eventData.content_types[1]];
+			// }
 		}
 		recentEvents.unshift(eventData);
 		index++;
@@ -653,7 +653,7 @@ export async function getEvents(globalContext: IDefaultGlobal): Promise<IEventDa
 			}
 		}
 		const lastEvent = _lev;
-		const currentEvents = ephemeral.events.map((ev) => getEventData(ev, globalContext.core.crew, globalContext.core.ship_schematics.map(m => m.ship), lastEvent))
+		const currentEvents = ephemeral.events.map((ev) => getEventData(ev, globalContext.core.crew, globalContext.core.all_ships.map(m => ({...m, levels: undefined })), lastEvent))
 			.filter(ev => ev !== undefined).map(ev => ev as IEventData)
 			.filter(ev => ev.seconds_to_end > 0)
 			.sort((a, b) => (a && b) ? (a.seconds_to_start - b.seconds_to_start) : a ? -1 : 1);


### PR DESCRIPTION
Rewrite ship table as functional component.
Adapting codebase to use all_ships in lieu of ship_schematics.

all_ships is a richer data set and is much more complete, and includes the almighty, elusive, Constellation Class ship.

Also clean up the profiles page to depend on global context and not load individual json files independently, anymore.