### PR TITLE
Bug fix. Fix export history on Production.

### DIFF
--- a/src/components/voyagehistory/manage.tsx
+++ b/src/components/voyagehistory/manage.tsx
@@ -266,6 +266,7 @@ const AdvancedOptions = () => {
 
 const DataManagementPlaceholder = (props: ManageRemoteSyncProps) => {
 	const { t } = React.useContext(GlobalContext).localized;
+	const { history } = React.useContext(HistoryContext);
 
 	const button: IManageButton = {
 		key: 'voyage.tracking.export',


### PR DESCRIPTION
Was not referencing the HistoryContext, and so was trying to stringify and download the global window.history variable.
